### PR TITLE
[#423] Refactor primitive types

### DIFF
--- a/src/analyze/build_type.ts
+++ b/src/analyze/build_type.ts
@@ -66,7 +66,7 @@ import { addErrorUnless } from '../util/traverse'
 import { buildPrimitiveTypeArgumentsError } from '../types/errors/annotations'
 import { findBinding } from '../util/bindings'
 import { getTypeVariables, getTypes } from '../util/scopes'
-import { assert } from '../types/errors/internal'
+import { assert, NotImplementedError } from '../types/errors/internal'
 
 type InternalTypeNode =
   | AccessTypeNode
@@ -171,6 +171,14 @@ export const buildType = <T extends State>(
   node: InternalTypeNode,
 ): Return<T, UnresolvedType> => {
   switch (node.type) {
+    case SyntaxType.AccessType:
+      throw new NotImplementedError(
+        'Tony cannot build access types yet.',
+      )
+    case SyntaxType.ConditionalType:
+      throw new NotImplementedError(
+        'Tony cannot build conditional types yet.',
+      )
     case SyntaxType.CurriedType:
       return handleCurriedType(state, node)
     case SyntaxType.IntersectionType:
@@ -181,12 +189,36 @@ export const buildType = <T extends State>(
       return handleMapType(state, node)
     case SyntaxType.ParametricType:
       return handleParametricType(state, node)
+    case SyntaxType.RefinementType:
+      throw new NotImplementedError(
+        'Tony cannot build refinement types yet.',
+      )
+    case SyntaxType.RefinementTypeDeclaration:
+      throw new NotImplementedError(
+        'Tony cannot build refinement types yet.',
+      )
     case SyntaxType.StructType:
       return handleStructType(state, node)
+    case SyntaxType.SubtractionType:
+      throw new NotImplementedError(
+        'Tony cannot build subtraction types yet.',
+      )
     case SyntaxType.TaggedType:
       return handleTaggedType(state, node)
     case SyntaxType.TupleType:
       return handleTupleType(state, node)
+    case SyntaxType.TypeGroup:
+      throw new NotImplementedError(
+        'Tony cannot build type groups yet.',
+      )
+    case SyntaxType.TypeVariable:
+      throw new NotImplementedError(
+        'Tony cannot build type variables yet.',
+      )
+    case SyntaxType.Typeof:
+      throw new NotImplementedError(
+        'Tony cannot build typeofs yet.',
+      )
     case SyntaxType.UnionType:
       return handleUnionType(state, node)
   }

--- a/src/analyze/build_type.ts
+++ b/src/analyze/build_type.ts
@@ -24,16 +24,11 @@ import {
   UnionTypeNode,
 } from 'tree-sitter-tony'
 import {
-  ConstrainedType,
-  buildConstrainedType,
-} from '../types/type_inference/constraints'
-import {
   DeclaredType,
   Property,
   RefinedTerm,
   RefinedType,
   TypeKind,
-  TypeVariable,
   UnresolvedType,
   buildCurriedType,
   buildGenericType,
@@ -46,27 +41,22 @@ import {
   buildUnionType,
 } from '../types/type_inference/types'
 import {
-  LocalTypeBinding,
-  TypeBinding,
-  TypeBindingNode,
-} from '../types/analyze/bindings'
-import { reduceConstraintTypes } from '../util/types'
+  NUMBER_TYPE,
+  buildPrimitiveType,
+  isPrimitiveTypeName,
+} from '../types/type_inference/primitive_types'
+import { NotImplementedError, assert } from '../types/errors/internal'
+import { ScopeWithErrors, ScopeWithTypes } from '../types/analyze/scopes'
 import {
   getIdentifierName,
   getTypeName,
   getTypeVariableName,
 } from '../util/parse'
-import {
-  NUMBER_TYPE,
-  buildPrimitiveType,
-  isPrimitiveTypeName,
-} from '../types/type_inference/primitive_types'
-import { ScopeWithErrors, ScopeWithTypes } from '../types/analyze/scopes'
+import { TypeBindingNode } from '../types/analyze/bindings'
 import { addErrorUnless } from '../util/traverse'
 import { buildPrimitiveTypeArgumentsError } from '../types/errors/annotations'
 import { findBinding } from '../util/bindings'
-import { getTypeVariables, getTypes } from '../util/scopes'
-import { assert, NotImplementedError } from '../types/errors/internal'
+import { getTypeVariables } from '../util/scopes'
 
 type InternalTypeNode =
   | AccessTypeNode
@@ -164,13 +154,9 @@ export const buildAliasedType = <T extends State>(
   switch (node.type) {
     case SyntaxType.Enum:
       // return union of typeofs of enum values
-      throw new NotImplementedError(
-        'Tony cannot handle enums yet.',
-      )
+      throw new NotImplementedError('Tony cannot handle enums yet.')
     case SyntaxType.Interface:
-      throw new NotImplementedError(
-        'Tony cannot handle interfaces yet.',
-      )
+      throw new NotImplementedError('Tony cannot handle interfaces yet.')
     case SyntaxType.TypeAlias:
       return buildType(state, node.typeNode)
   }
@@ -186,13 +172,9 @@ export const buildType = <T extends State>(
 ): Return<T, UnresolvedType> => {
   switch (node.type) {
     case SyntaxType.AccessType:
-      throw new NotImplementedError(
-        'Tony cannot build access types yet.',
-      )
+      throw new NotImplementedError('Tony cannot build access types yet.')
     case SyntaxType.ConditionalType:
-      throw new NotImplementedError(
-        'Tony cannot build conditional types yet.',
-      )
+      throw new NotImplementedError('Tony cannot build conditional types yet.')
     case SyntaxType.CurriedType:
       return handleCurriedType(state, node)
     case SyntaxType.IntersectionType:
@@ -204,35 +186,23 @@ export const buildType = <T extends State>(
     case SyntaxType.ParametricType:
       return handleParametricType(state, node)
     case SyntaxType.RefinementType:
-      throw new NotImplementedError(
-        'Tony cannot build refinement types yet.',
-      )
+      throw new NotImplementedError('Tony cannot build refinement types yet.')
     case SyntaxType.RefinementTypeDeclaration:
-      throw new NotImplementedError(
-        'Tony cannot build refinement types yet.',
-      )
+      throw new NotImplementedError('Tony cannot build refinement types yet.')
     case SyntaxType.StructType:
       return handleStructType(state, node)
     case SyntaxType.SubtractionType:
-      throw new NotImplementedError(
-        'Tony cannot build subtraction types yet.',
-      )
+      throw new NotImplementedError('Tony cannot build subtraction types yet.')
     case SyntaxType.TaggedType:
       return handleTaggedType(state, node)
     case SyntaxType.TupleType:
       return handleTupleType(state, node)
     case SyntaxType.TypeGroup:
-      throw new NotImplementedError(
-        'Tony cannot build type groups yet.',
-      )
+      throw new NotImplementedError('Tony cannot build type groups yet.')
     case SyntaxType.TypeVariable:
-      throw new NotImplementedError(
-        'Tony cannot build type variables yet.',
-      )
+      throw new NotImplementedError('Tony cannot build type variables yet.')
     case SyntaxType.Typeof:
-      throw new NotImplementedError(
-        'Tony cannot build typeofs yet.',
-      )
+      throw new NotImplementedError('Tony cannot build typeofs yet.')
     case SyntaxType.UnionType:
       return handleUnionType(state, node)
   }

--- a/src/analyze/build_type.ts
+++ b/src/analyze/build_type.ts
@@ -160,7 +160,21 @@ const findTypeVariable = <T extends State>(
 export const buildAliasedType = <T extends State>(
   state: T,
   node: TypeBindingNode,
-): Return<T, UnresolvedType> => {}
+): Return<T, UnresolvedType> => {
+  switch (node.type) {
+    case SyntaxType.Enum:
+      // return union of typeofs of enum values
+      throw new NotImplementedError(
+        'Tony cannot handle enums yet.',
+      )
+    case SyntaxType.Interface:
+      throw new NotImplementedError(
+        'Tony cannot handle interfaces yet.',
+      )
+    case SyntaxType.TypeAlias:
+      return buildType(state, node.typeNode)
+  }
+}
 
 /**
  * Given a node in the syntax tree and some state, returns the type represented

--- a/src/analyze/build_type.ts
+++ b/src/analyze/build_type.ts
@@ -46,7 +46,11 @@ import {
   reduceConstraintTypes,
 } from '../util/types'
 import { getIdentifierName, getTypeName } from '../util/parse'
-import { NUMBER_TYPE } from '../types/type_inference/primitive_types'
+import {
+  NUMBER_TYPE,
+  buildPrimitiveType,
+  isPrimitiveTypeName,
+} from '../types/type_inference/primitive_types'
 
 type InternalTypeNode =
   | AccessTypeNode
@@ -71,7 +75,7 @@ type InternalTypeNode =
  * Given a node in the syntax tree and a stack of type bindings, returns the
  * type defined by the node.
  */
-export const buildTypeBindingType = (types: TypeBinding[][]) => (
+export const buildAliasType = (types: TypeBinding[][]) => (
   node: TypeBindingNode,
 ): ConstrainedType<DeclaredType, UnresolvedType> => {
   switch (node.type) {
@@ -117,7 +121,7 @@ const handleTypeVariableDeclaration = (
  * Given a node in the syntax tree and a stack of type bindings, returns the
  * type represented by the type binding.
  */
-export const buildTypeBindingValueType = (types: TypeBinding[][]) => (
+export const buildAliasedType = (types: TypeBinding[][]) => (
   node: TypeBindingNode,
 ): UnresolvedType => {}
 
@@ -183,6 +187,11 @@ const handleParametricType = (
   node: ParametricTypeNode,
 ) => {
   const name = getTypeName(node.nameNode)
+  if (isPrimitiveTypeName(name)) {
+    // TODO: add error if there are type or term arguments
+    return buildPrimitiveType(name)
+  }
+
   const typeArguments = node.argumentNodes.map(buildType(types))
   const termArguments = node.elementNodes
   return buildParametricType(name, typeArguments, termArguments)

--- a/src/analyze/file_scope.ts
+++ b/src/analyze/file_scope.ts
@@ -66,6 +66,7 @@ import { Config } from '../config'
 import { assert } from '../types/errors/internal'
 import { fileMayBeImported } from '../util/paths'
 import { resolveRelativePath } from './resolve'
+import { isPrimitiveTypeName } from '../types/type_inference/primitive_types'
 
 type ImportedBindingConfig = { file: AbsolutePath; originalName?: string }
 
@@ -227,7 +228,9 @@ const addTypeBinding = (
   importedFrom?: ImportedBindingConfig,
 ) =>
   ensure<State, TypeBindingNode | ImportTypeNode>(
-    (state) => findBinding(name, state.scopes.map(getTypes)) === undefined,
+    (state) =>
+      findBinding(name, state.scopes.map(getTypes)) === undefined &&
+      !isPrimitiveTypeName(name),
     (state, node) => {
       const binding = importedFrom
         ? buildImportedTypeBinding(

--- a/src/analyze/file_scope.ts
+++ b/src/analyze/file_scope.ts
@@ -48,6 +48,7 @@ import {
   buildTypeVariableBinding,
 } from '../types/analyze/bindings'
 import { addError, conditionalApply, ensure } from '../util/traverse'
+import { buildAliasType, buildAliasedType, buildTypes } from './build_type'
 import {
   buildDuplicateBindingError,
   buildExportOutsideFileScopeError,
@@ -67,16 +68,11 @@ import {
 import { getTerms, getTypeVariables, getTypes } from '../util/scopes'
 import { Config } from '../config'
 import { assert } from '../types/errors/internal'
-import { fileMayBeImported } from '../util/paths'
-import { resolveRelativePath } from './resolve'
-import { isPrimitiveTypeName } from '../types/type_inference/primitive_types'
-import { buildAliasType, buildAliasedType, buildTypes } from './build_type'
-import {
-  buildTypeConstraints,
-  buildTypeVariableAssignment,
-} from '../types/type_inference/constraints'
-import { buildTypeVariable } from '../types/type_inference/types'
 import { buildTypeConstraintsFromTypes } from '../util/types'
+import { buildTypeVariable } from '../types/type_inference/types'
+import { fileMayBeImported } from '../util/paths'
+import { isPrimitiveTypeName } from '../types/type_inference/primitive_types'
+import { resolveRelativePath } from './resolve'
 
 type ImportedBindingConfig = { file: AbsolutePath; originalName?: string }
 

--- a/src/type_inference/resolve_bindings.ts
+++ b/src/type_inference/resolve_bindings.ts
@@ -126,7 +126,7 @@ export const resolveTermBindingType = resolveBindingType<
 >(getTypeAssignments, resolveTermBindingTypeWithinScope)
 
 const resolveAliasTypeWithinScope = (typeBinding: LocalTypeBinding) =>
-  buildConstrainedType(typeBinding.type, typeBinding.constraints)
+  buildConstrainedType(typeBinding.value)
 
 /**
  * Returns the type declared by a type binding.
@@ -138,7 +138,7 @@ export const resolveAliasType = resolveBindingType<
 >(getTypes, resolveAliasTypeWithinScope)
 
 const resolveAliasedTypeWithinScope = (typeBinding: LocalTypeBinding) =>
-  buildConstrainedType(typeBinding.value, typeBinding.constraints)
+  buildConstrainedType(typeBinding.alias)
 
 /**
  * Returns the type represented by a type binding.

--- a/src/type_inference/resolve_bindings.ts
+++ b/src/type_inference/resolve_bindings.ts
@@ -125,27 +125,26 @@ export const resolveTermBindingType = resolveBindingType<
   Type
 >(getTypeAssignments, resolveTermBindingTypeWithinScope)
 
-const resolveTypeBindingTypeWithinScope = (typeBinding: LocalTypeBinding) =>
+const resolveAliasTypeWithinScope = (typeBinding: LocalTypeBinding) =>
   buildConstrainedType(typeBinding.type, typeBinding.constraints)
 
 /**
  * Returns the type declared by a type binding.
  */
-export const resolveTypeBindingType = resolveBindingType<
+export const resolveAliasType = resolveBindingType<
   TypeBinding,
   ScopeWithErrors,
   DeclaredType
->(getTypes, resolveTypeBindingTypeWithinScope)
+>(getTypes, resolveAliasTypeWithinScope)
 
-const resolveTypeBindingValueTypeWithinScope = (
-  typeBinding: LocalTypeBinding,
-) => buildConstrainedType(typeBinding.value, typeBinding.constraints)
+const resolveAliasedTypeWithinScope = (typeBinding: LocalTypeBinding) =>
+  buildConstrainedType(typeBinding.value, typeBinding.constraints)
 
 /**
  * Returns the type represented by a type binding.
  */
-export const resolveTypeBindingValueType = resolveBindingType<
+export const resolveAliasedType = resolveBindingType<
   TypeBinding,
   ScopeWithErrors,
   UnresolvedType
->(getTypes, resolveTypeBindingValueTypeWithinScope)
+>(getTypes, resolveAliasedTypeWithinScope)

--- a/src/types/analyze/bindings.ts
+++ b/src/types/analyze/bindings.ts
@@ -20,10 +20,7 @@ import {
   TypeAliasNode,
   TypeVariableDeclarationNode,
 } from 'tree-sitter-tony'
-import {
-  buildTypeBindingType,
-  buildTypeBindingValueType,
-} from '../../analyze/build_type'
+import { buildAliasType, buildAliasedType } from '../../analyze/build_type'
 import { AbsolutePath } from '../path'
 
 // ---- Types ----
@@ -161,7 +158,7 @@ export const buildLocalTypeBinding = (
   node: TypeBindingNode,
   isExported = false,
 ): LocalTypeBinding => {
-  const constrainedType = buildTypeBindingType(typeBindings)(node)
+  const constrainedType = buildAliasType(typeBindings)(node)
 
   return {
     kind: BindingKind.Type,
@@ -170,7 +167,7 @@ export const buildLocalTypeBinding = (
     node,
     isExported,
     type: constrainedType.type,
-    value: buildTypeBindingValueType(typeBindings)(node),
+    value: buildAliasedType(typeBindings)(node),
     constraints: constrainedType.constraints,
   }
 }

--- a/src/types/analyze/bindings.ts
+++ b/src/types/analyze/bindings.ts
@@ -5,7 +5,6 @@ import {
   Type,
   TypeVariable,
   UnresolvedType,
-  buildTypeVariable,
 } from '../type_inference/types'
 import {
   DestructuringPatternNode,
@@ -22,7 +21,6 @@ import {
   TypeAliasNode,
   TypeVariableDeclarationNode,
 } from 'tree-sitter-tony'
-import { buildAliasType, buildAliasedType } from '../../analyze/build_type'
 import { AbsolutePath } from '../path'
 
 // ---- Types ----

--- a/src/types/analyze/bindings.ts
+++ b/src/types/analyze/bindings.ts
@@ -153,24 +153,22 @@ export const buildImportedTypeBinding = (
 })
 
 export const buildLocalTypeBinding = (
-  typeBindings: TypeBinding[][],
   name: string,
+  type: DeclaredType,
+  value: UnresolvedType,
+  constraints: TypeConstraints<UnresolvedType>,
   node: TypeBindingNode,
   isExported = false,
-): LocalTypeBinding => {
-  const constrainedType = buildAliasType(typeBindings)(node)
-
-  return {
-    kind: BindingKind.Type,
-    location: BindingLocation.Local,
-    name,
-    node,
-    isExported,
-    type: constrainedType.type,
-    value: buildAliasedType(typeBindings)(node),
-    constraints: constrainedType.constraints,
-  }
-}
+): LocalTypeBinding => ({
+  kind: BindingKind.Type,
+  location: BindingLocation.Local,
+  name,
+  node,
+  isExported,
+  type,
+  value,
+  constraints,
+})
 
 export const buildTypeAssignment = <T extends Type>(
   binding: TermBinding,

--- a/src/types/analyze/scopes.ts
+++ b/src/types/analyze/scopes.ts
@@ -10,7 +10,12 @@ import {
 } from 'tree-sitter-tony'
 import { ErrorAnnotation, MountedErrorAnnotation } from '../errors/annotations'
 import { ResolvedType, Type } from '../type_inference/types'
-import { TermBinding, TypeAssignment, TypeBinding } from './bindings'
+import {
+  TermBinding,
+  TypeAssignment,
+  TypeBinding,
+  TypeVariableBinding,
+} from './bindings'
 import { AbsolutePath } from '../path'
 import { TypedNode } from '../type_inference/nodes'
 
@@ -42,6 +47,7 @@ export type TypingEnvironment<T extends Type> = {
 
 export type ScopeWithTypes = {
   types: TypeBinding[]
+  typeVariables: TypeVariableBinding[]
 }
 
 export type ScopeWithErrors = {
@@ -113,6 +119,7 @@ export const buildFileScope = (
   dependencies: [],
   terms: [],
   types: [],
+  typeVariables: [],
   errors: [],
 })
 
@@ -133,6 +140,7 @@ export const buildNestedScope = (node: NestingNode): NestedScope => ({
   node,
   terms: [],
   types: [],
+  typeVariables: [],
   scopes: [],
   errors: [],
 })

--- a/src/types/errors/annotations.ts
+++ b/src/types/errors/annotations.ts
@@ -19,6 +19,7 @@ export enum ErrorAnnotationKind {
   IndeterminateType,
   MissingBinding,
   MissingExternalImportTypeHint,
+  PrimitiveTypeArguments,
   RefinementTypeDeclarationOutsideRefinementType,
   Type,
   UnknownFile,
@@ -70,6 +71,10 @@ export type MissingExternalImportTypeHintError = {
   binding: TermBinding
 }
 
+export type PrimitiveTypeArgumentsError = {
+  kind: typeof ErrorAnnotationKind.PrimitiveTypeArguments
+}
+
 export type RefinementTypeDeclarationOutsideRefinementTypeError = {
   kind: typeof ErrorAnnotationKind.RefinementTypeDeclarationOutsideRefinementType
 }
@@ -110,6 +115,7 @@ export type ErrorAnnotation =
   | IndeterminateTypeError
   | MissingBindingError
   | MissingExternalImportTypeHintError
+  | PrimitiveTypeArgumentsError
   | RefinementTypeDeclarationOutsideRefinementTypeError
   | TypeError
   | UnknownFileError
@@ -165,6 +171,10 @@ export const buildMissingBindingError = (
 ): MissingBindingError => ({
   kind: ErrorAnnotationKind.MissingBinding,
   name,
+})
+
+export const buildPrimitiveTypeArgumentsError = (): PrimitiveTypeArgumentsError => ({
+  kind: ErrorAnnotationKind.PrimitiveTypeArguments,
 })
 
 export const buildRefinementTypeDeclarationOutsideRefinementTypeError = (): RefinementTypeDeclarationOutsideRefinementTypeError => ({

--- a/src/types/type_inference/constraints.ts
+++ b/src/types/type_inference/constraints.ts
@@ -43,3 +43,11 @@ export const buildConstrainedType = <
 export const buildTypeConstraints = <T extends Type>(
   constraints: TypeVariableAssignment<T>[] = [],
 ): TypeConstraints<T> => constraints
+
+export const buildTypeVariableAssignment = <T extends Type>(
+  typeVariable: TypeVariable,
+  type: T,
+): TypeVariableAssignment<T> => ({
+  typeVariable,
+  type,
+})

--- a/src/types/type_inference/primitive_types.ts
+++ b/src/types/type_inference/primitive_types.ts
@@ -1,4 +1,3 @@
-import { TypeofNode } from 'tree-sitter-tony'
 import { TypeKind } from './types'
 
 // ---- Types ----

--- a/src/types/type_inference/primitive_types.ts
+++ b/src/types/type_inference/primitive_types.ts
@@ -1,3 +1,4 @@
+import { TypeofNode } from 'tree-sitter-tony'
 import { TypeKind } from './types'
 
 // ---- Types ----
@@ -41,3 +42,45 @@ export const NUMBER_TYPE: NumberType = { kind: TypeKind.Number }
 export const REG_EXP_TYPE: RegExpType = { kind: TypeKind.RegExp }
 export const STRING_TYPE: StringType = { kind: TypeKind.String }
 export const VOID_TYPE: VoidType = { kind: TypeKind.Void }
+
+const BOOLEAN_TYPE_NAME = 'Boolean'
+const NUMBER_TYPE_NAME = 'Number'
+const REG_EXP_TYPE_NAME = 'RegularExpression'
+const STRING_TYPE_NAME = 'String'
+const VOID_TYPE_NAME = 'Void'
+const PRIMITIVE_TYPE_NAMES: PrimitiveTypeName[] = [
+  BOOLEAN_TYPE_NAME,
+  NUMBER_TYPE_NAME,
+  REG_EXP_TYPE_NAME,
+  STRING_TYPE_NAME,
+  VOID_TYPE_NAME,
+]
+
+type PrimitiveTypeName =
+  | typeof BOOLEAN_TYPE_NAME
+  | typeof NUMBER_TYPE_NAME
+  | typeof REG_EXP_TYPE_NAME
+  | typeof STRING_TYPE_NAME
+  | typeof VOID_TYPE_NAME
+
+// ---- Factories ----
+
+export const buildPrimitiveType = (name: PrimitiveTypeName): PrimitiveType => {
+  switch (name) {
+    case BOOLEAN_TYPE_NAME:
+      return BOOLEAN_TYPE
+    case NUMBER_TYPE_NAME:
+      return NUMBER_TYPE
+    case REG_EXP_TYPE_NAME:
+      return REG_EXP_TYPE
+    case STRING_TYPE_NAME:
+      return STRING_TYPE
+    case VOID_TYPE_NAME:
+      return VOID_TYPE
+  }
+}
+
+export const isPrimitiveTypeName = (
+  value: string,
+): value is PrimitiveTypeName =>
+  PRIMITIVE_TYPE_NAMES.includes(value as PrimitiveTypeName)

--- a/src/util/scopes.ts
+++ b/src/util/scopes.ts
@@ -10,6 +10,7 @@ import {
   TermBinding,
   TypeAssignment,
   TypeBinding,
+  TypeVariableBinding,
 } from '../types/analyze/bindings'
 import { AbsolutePath } from '../types/path'
 import { ErrorAnnotation } from '../types/errors/annotations'
@@ -34,6 +35,9 @@ export const addErrorToScope = <T extends ScopeWithErrors>(
 
 export const getTerms = (scope: ScopeWithTerms): TermBinding[] => scope.terms
 export const getTypes = (scope: ScopeWithTypes): TypeBinding[] => scope.types
+export const getTypeVariables = (
+  scope: ScopeWithTypes,
+): TypeVariableBinding[] => scope.typeVariables
 export const getTypeAssignments = <T extends Type>(
   scope: TypingEnvironment<T>,
 ): TypeAssignment<T>[] => scope.typeAssignments

--- a/src/util/traverse.ts
+++ b/src/util/traverse.ts
@@ -1,10 +1,10 @@
-import { FileScope, NestedScope } from '../types/analyze/scopes'
+import { ScopeWithErrors } from '../types/analyze/scopes'
 import { ErrorAnnotation } from '../types/errors/annotations'
 import { SyntaxNode } from 'tree-sitter-tony'
 import { addErrorToScope } from './scopes'
 
 type State = {
-  scopes: (FileScope | NestedScope)[]
+  scopes: ScopeWithErrors[]
 }
 
 export const addError = <T extends State>(

--- a/src/util/traverse.ts
+++ b/src/util/traverse.ts
@@ -1,5 +1,5 @@
-import { ScopeWithErrors } from '../types/analyze/scopes'
 import { ErrorAnnotation } from '../types/errors/annotations'
+import { ScopeWithErrors } from '../types/analyze/scopes'
 import { SyntaxNode } from 'tree-sitter-tony'
 import { addErrorToScope } from './scopes'
 

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -2,6 +2,7 @@ import {
   ConstrainedType,
   TypeConstraints,
   buildConstrainedType,
+  buildTypeVariableAssignment,
 } from '../types/type_inference/constraints'
 import {
   DeclaredType,
@@ -21,15 +22,13 @@ export const buildConstrainedUnknownType = <T extends Type>(
 ): ConstrainedType<TypeVariable, T> =>
   buildConstrainedType(buildTypeVariable(), constraints)
 
-export const buildConstrainedUnknownTypeFromTypes = <T extends Type>(
-  types: T[],
-): ConstrainedType<TypeVariable, T> => {
-  const typeVariable = buildTypeVariable()
-  return buildConstrainedType(
-    typeVariable,
-    types.map((type) => ({ typeVariable, type })),
+export const buildTypeConstraintsFromTypes = <T extends Type>(
+  typeVariable: TypeVariable,
+  constraints: T[] = [],
+): TypeConstraints<T> =>
+  constraints.map((constraint) =>
+    buildTypeVariableAssignment(typeVariable, constraint),
   )
-}
 
 export const reduceConstraintTypes = <
   T extends DeclaredType | Type,


### PR DESCRIPTION
To do:

- [x] add errors from `buildType`
- [x] call `buildAliasType` and `buildAliasedType` directly from `file_scope.ts` instead of from factory
- [x] add error if parametric type node builds primitive type but has type or term arguments
- [x] fix TypeScript errors in `buildType` (create issues for not implemented cases)
- [x] implement `buildAliasedType`
