### PR TITLE
[#482] Type unification

### DIFF
--- a/src/analyze/build_type.ts
+++ b/src/analyze/build_type.ts
@@ -43,7 +43,6 @@ import {
   Property,
   RefinedTerm,
   RefinedType,
-  TypeKind,
   UnresolvedType,
   buildAccessType,
   buildConditionalType,
@@ -75,6 +74,7 @@ import { getTerms, getTypeVariables } from '../util/scopes'
 import { TypeBindingNode } from '../types/analyze/bindings'
 import { addErrorUnless } from '../util/traverse'
 import { buildPrimitiveTypeArgumentsError } from '../types/errors/annotations'
+import { flattenType } from '../util/types'
 
 type InternalTypeNode =
   | AccessTypeNode
@@ -303,11 +303,7 @@ const handleIntersectionType = <T extends State>(
 ): Return<T, UnresolvedType> => {
   const [stateWithLeft, left] = buildType(state, node.leftNode)
   const [stateWithRight, right] = buildType(stateWithLeft, node.rightNode)
-  const type =
-    right.kind === TypeKind.Intersection
-      ? buildIntersectionType([left, ...right.parameters])
-      : buildIntersectionType([left, right])
-  return [stateWithRight, type]
+  return [stateWithRight, flattenType(buildIntersectionType([left, right]))]
 }
 
 const handleListType = <T extends State>(
@@ -421,11 +417,7 @@ const handleUnionType = <T extends State>(
 ): Return<T, UnresolvedType> => {
   const [stateWithLeft, left] = buildType(state, node.leftNode)
   const [stateWithRight, right] = buildType(stateWithLeft, node.rightNode)
-  const type =
-    right.kind === TypeKind.Union
-      ? buildUnionType([left, ...right.parameters])
-      : buildUnionType([left, right])
-  return [stateWithRight, type]
+  return [stateWithRight, flattenType(buildUnionType([left, right]))]
 }
 
 const handleEnumValue = <T extends State>(

--- a/src/type_inference/generalization.ts
+++ b/src/type_inference/generalization.ts
@@ -1,9 +1,0 @@
-import { ResolvedConstrainedType } from '../types/type_inference/constraints'
-
-/**
- * Given a set of types, return the least general type such that all types in
- * the set are instances of that type.
- */
-export const generalize = (
-  ...types: ResolvedConstrainedType[]
-): ResolvedConstrainedType => {}

--- a/src/type_inference/index.ts
+++ b/src/type_inference/index.ts
@@ -404,10 +404,12 @@ const traverseAll = <T extends TermNode>(
   }, [])
 
 const unifyConstraintsWithTypedNode = <T extends TermNode>(
+  state: State,
   typedNode: TypedNode<T>,
   constraints: TypeConstraints<ResolvedType>,
 ): TypedNode<T> => {
   const unifiedConstraints = unifyConstraints(
+    state,
     constraints,
     typedNode.type.constraints,
   )
@@ -437,7 +439,11 @@ const ensureIsInstanceOf = <T extends TermNode>(
     answer.state,
     node,
   )
-  const typedNode = unifyConstraintsWithTypedNode(answer.typedNode, constraints)
+  const typedNode = unifyConstraintsWithTypedNode(
+    answer.state,
+    answer.typedNode,
+    constraints,
+  )
   return buildAnswer(stateWithError, typedNode)
 }
 

--- a/src/type_inference/instances.ts
+++ b/src/type_inference/instances.ts
@@ -12,12 +12,3 @@ export const isInstanceOf = (
   specific: ResolvedConstrainedType,
   general: ResolvedConstrainedType,
 ): [isInstanceOf: boolean, typeConstraints: TypeConstraints<ResolvedType>] => {}
-
-/**
- * Given a specific and a general type, determines whether the specific type may
- * be an instance of the general type.
- */
-export const mayBeInstanceOf = (
-  specific: ResolvedConstrainedType,
-  general: ResolvedConstrainedType,
-): [isInstanceOf: boolean, typeConstraints: TypeConstraints<ResolvedType>] => {}

--- a/src/type_inference/normalization.ts
+++ b/src/type_inference/normalization.ts
@@ -1,9 +1,16 @@
-import { ResolvedConstrainedType } from '../types/type_inference/constraints'
+import { ConstrainedType } from '../types/type_inference/constraints'
+import { ScopeWithErrors } from '../types/analyze/scopes'
+import { Type } from '../types/type_inference/types'
+
+type State = {
+  scopes: ScopeWithErrors[]
+}
 
 /**
  * Given a type, reduce the type until it is normal (i.e. cannot be reduced
  * further).
  */
-export const normalize = (
-  type: ResolvedConstrainedType,
-): ResolvedConstrainedType => {}
+export const normalize = <T extends State>(
+  state: T,
+  type: ConstrainedType<Type>,
+): ConstrainedType<Type> => {}

--- a/src/type_inference/unification.ts
+++ b/src/type_inference/unification.ts
@@ -9,12 +9,15 @@ import {
   Type,
   TypeKind,
   TypeVariable,
+  buildIntersectionType,
 } from '../types/type_inference/types'
 import {
   buildTypeConstraintsFromType,
   buildUnconstrainedUnknownType,
+  flattenType,
 } from '../util/types'
 import { ScopeWithErrors } from '../types/analyze/scopes'
+import { normalize } from './normalization'
 import { unifyConstraints } from './constraints'
 
 type State = {
@@ -22,7 +25,7 @@ type State = {
 }
 
 /**
- * Given a set of types, return the most general type such that all types in
+ * Given a set of types, return the least general type such that all types in
  * the set are instances of that type.
  */
 export const unify = <T extends State, U extends Type>(
@@ -53,6 +56,11 @@ const concreteUnify = <T extends State>(
       return unifyWithTypeVariable(left, right)
     case TypeKind.TemporaryVariable:
       return buildConstrainedType(right)
+    default:
+      return normalize(
+        state,
+        buildConstrainedType(flattenType(buildIntersectionType([left, right]))),
+      )
   }
 }
 

--- a/src/type_inference/unification.ts
+++ b/src/type_inference/unification.ts
@@ -1,49 +1,53 @@
 import {
   ConstrainedType,
-  ResolvedConstrainedType,
   buildConstrainedType,
   buildTypeConstraints,
   buildTypeVariableAssignment,
 } from '../types/type_inference/constraints'
 import {
-  ResolvedType,
+  TemporaryTypeVariable,
   Type,
   TypeKind,
   TypeVariable,
-  UnresolvedType,
 } from '../types/type_inference/types'
 import {
   buildTypeConstraintsFromTypes,
   buildUnconstrainedUnknownType,
 } from '../util/types'
+import { ScopeWithErrors } from '../types/analyze/scopes'
 import { unifyConstraints } from './constraints'
 
-/**
- * Given a set of types, return the most general type such that all types in
- * the set are instances of that type.
- */
-export const unifyUnresolved = <T extends Type>(
-  ...types: T[]
-): ConstrainedType<T, UnresolvedType> => {}
+type State = {
+  scopes: ScopeWithErrors[]
+}
 
 /**
  * Given a set of types, return the most general type such that all types in
  * the set are instances of that type.
  */
-export const unify = (types: ResolvedType[]): ResolvedConstrainedType =>
-  types.reduce<ResolvedConstrainedType>((left, right) => {
-    const constrainedType = unconstrainedConcreteUnify(left.type, right)
+export const unify = <T extends State, U extends Type>(
+  state: T,
+  ...types: U[]
+): ConstrainedType<U | TemporaryTypeVariable> =>
+  types.reduce<ConstrainedType<U | TemporaryTypeVariable>>((left, right) => {
+    const constrainedType = unconstrainedConcreteUnify(
+      state,
+      left.type,
+      right,
+    ) as ConstrainedType<U>
     const constraints = unifyConstraints(
+      state,
       left.constraints,
       constrainedType.constraints,
     )
     return buildConstrainedType(constrainedType.type, constraints)
   }, buildUnconstrainedUnknownType())
 
-const unconstrainedConcreteUnify = (
-  left: ResolvedType,
-  right: ResolvedType,
-): ResolvedConstrainedType => {
+const unconstrainedConcreteUnify = <T extends State>(
+  state: T,
+  left: Type,
+  right: Type,
+): ConstrainedType<Type> => {
   switch (left.kind) {
     case TypeKind.Variable:
       return unifyWithTypeVariable(left, right)
@@ -52,10 +56,7 @@ const unconstrainedConcreteUnify = (
   }
 }
 
-const unifyWithTypeVariable = (
-  left: TypeVariable,
-  right: ResolvedType,
-): ResolvedConstrainedType => {
+const unifyWithTypeVariable = (left: TypeVariable, right: Type) => {
   if (right.kind === TypeKind.Variable)
     return buildConstrainedType(
       left,

--- a/src/type_inference/unification.ts
+++ b/src/type_inference/unification.ts
@@ -11,7 +11,7 @@ import {
   TypeVariable,
 } from '../types/type_inference/types'
 import {
-  buildTypeConstraintsFromTypes,
+  buildTypeConstraintsFromType,
   buildUnconstrainedUnknownType,
 } from '../util/types'
 import { ScopeWithErrors } from '../types/analyze/scopes'
@@ -62,8 +62,5 @@ const unifyWithTypeVariable = (left: TypeVariable, right: Type) => {
       left,
       buildTypeConstraints([buildTypeVariableAssignment([left, right])]),
     )
-  return buildConstrainedType(
-    right,
-    buildTypeConstraintsFromTypes(left, [right]),
-  )
+  return buildConstrainedType(right, buildTypeConstraintsFromType(left, right))
 }

--- a/src/type_inference/unification.ts
+++ b/src/type_inference/unification.ts
@@ -30,7 +30,7 @@ export const unify = <T extends State, U extends Type>(
   ...types: U[]
 ): ConstrainedType<U | TemporaryTypeVariable> =>
   types.reduce<ConstrainedType<U | TemporaryTypeVariable>>((left, right) => {
-    const constrainedType = unconstrainedConcreteUnify(
+    const constrainedType = concreteUnify(
       state,
       left.type,
       right,
@@ -43,7 +43,7 @@ export const unify = <T extends State, U extends Type>(
     return buildConstrainedType(constrainedType.type, constraints)
   }, buildUnconstrainedUnknownType())
 
-const unconstrainedConcreteUnify = <T extends State>(
+const concreteUnify = <T extends State>(
   state: T,
   left: Type,
   right: Type,

--- a/src/type_inference/unification.ts
+++ b/src/type_inference/unification.ts
@@ -10,37 +10,27 @@ import {
   Type,
   TypeKind,
   TypeVariable,
+  UnresolvedType,
 } from '../types/type_inference/types'
 import {
   buildTypeConstraintsFromTypes,
   buildUnconstrainedUnknownType,
 } from '../util/types'
-import { flattenConstrainedType, unifyConstraints } from './constraints'
+import { unifyConstraints } from './constraints'
 
 /**
  * Given a set of types, return the most general type such that all types in
  * the set are instances of that type.
  */
-export const unifyUnresolved = <T extends Type, U extends Type>(
-  ...types: ConstrainedType<T, U>[]
-): ConstrainedType<T, U> => {}
+export const unifyUnresolved = <T extends Type>(
+  ...types: T[]
+): ConstrainedType<T, UnresolvedType> => {}
 
 /**
  * Given a set of types, return the most general type such that all types in
  * the set are instances of that type.
  */
-export const unify = (
-  ...types: ResolvedConstrainedType[]
-): ResolvedConstrainedType => {
-  const constrainedType = unconstrainedUnify(types.map(flattenConstrainedType))
-  const unifiedConstraints = unifyConstraints(
-    constrainedType.constraints,
-    ...types.map((type) => type.constraints),
-  )
-  return buildConstrainedType(constrainedType.type, unifiedConstraints)
-}
-
-const unconstrainedUnify = (types: ResolvedType[]) =>
+export const unify = (types: ResolvedType[]): ResolvedConstrainedType =>
   types.reduce<ResolvedConstrainedType>((left, right) => {
     const constrainedType = unconstrainedConcreteUnify(left.type, right)
     const constraints = unifyConstraints(
@@ -57,6 +47,8 @@ const unconstrainedConcreteUnify = (
   switch (left.kind) {
     case TypeKind.Variable:
       return unifyWithTypeVariable(left, right)
+    case TypeKind.TemporaryVariable:
+      return buildConstrainedType(right)
   }
 }
 

--- a/src/types/analyze/bindings.ts
+++ b/src/types/analyze/bindings.ts
@@ -1,7 +1,5 @@
-import { ConstrainedType, TypeConstraints } from '../type_inference/constraints'
 import {
   DeclaredType,
-  ResolvedType,
   Type,
   TypeVariable,
   UnresolvedType,
@@ -22,6 +20,7 @@ import {
   TypeVariableDeclarationNode,
 } from 'tree-sitter-tony'
 import { AbsolutePath } from '../path'
+import { TypeConstraints } from '../type_inference/constraints'
 
 // ---- Types ----
 
@@ -108,7 +107,7 @@ export type TypeVariableBinding = AbstractBinding & {
  * A type assignment assigns a type to a term binding.
  */
 export type TypeAssignment<T extends Type> = TermBinding & {
-  type: ConstrainedType<T, ResolvedType>
+  type: T
 }
 
 // ---- Factories ----
@@ -197,7 +196,7 @@ export const buildTypeVariableBinding = (
 
 export const buildTypeAssignment = <T extends Type>(
   binding: TermBinding,
-  type: ConstrainedType<T, ResolvedType>,
+  type: T,
 ): TypeAssignment<T> => ({
   ...binding,
   type,

--- a/src/types/type_inference/constraints.ts
+++ b/src/types/type_inference/constraints.ts
@@ -5,7 +5,10 @@ import { DeclaredType, ResolvedType, Type, TypeVariable } from './types'
 /**
  * A constrained type represents a type alongside constraints on type variables.
  */
-export type ConstrainedType<T extends DeclaredType | Type, U extends Type> = {
+export type ConstrainedType<
+  T extends DeclaredType | Type,
+  U extends Type = Type
+> = {
   type: T
   constraints: TypeConstraints<U>
 }

--- a/src/types/type_inference/constraints.ts
+++ b/src/types/type_inference/constraints.ts
@@ -20,7 +20,7 @@ export type ResolvedConstrainedType = ConstrainedType<
 /**
  * A set of assignments of type variables to their most general type.
  */
-export type TypeConstraints<T extends Type> = TypeVariableAssignment<T>[]
+export type TypeConstraints<T extends Type = Type> = TypeVariableAssignment<T>[]
 
 /**
  * Maps a set of type variables to their most general type (if any).

--- a/src/types/type_inference/constraints.ts
+++ b/src/types/type_inference/constraints.ts
@@ -20,11 +20,11 @@ export type ResolvedConstrainedType = ConstrainedType<
 export type TypeConstraints<T extends Type> = TypeVariableAssignment<T>[]
 
 /**
- * Maps a type variable to its most general type.
+ * Maps a set of type variables to their most general type (if any).
  */
-export type TypeVariableAssignment<T extends Type> = {
-  typeVariable: TypeVariable
-  type: T
+export type TypeVariableAssignment<T extends Type = Type> = {
+  typeVariables: TypeVariable[]
+  type?: T
 }
 
 // ---- Factories ----
@@ -45,9 +45,9 @@ export const buildTypeConstraints = <T extends Type>(
 ): TypeConstraints<T> => constraints
 
 export const buildTypeVariableAssignment = <T extends Type>(
-  typeVariable: TypeVariable,
-  type: T,
+  typeVariables: TypeVariable[],
+  type?: T,
 ): TypeVariableAssignment<T> => ({
-  typeVariable,
+  typeVariables,
   type,
 })

--- a/src/types/type_inference/types.ts
+++ b/src/types/type_inference/types.ts
@@ -23,6 +23,7 @@ export enum TypeKind {
   RefinedTerm,
   Subtraction,
   Tagged,
+  TemporaryVariable,
   Term,
   Union,
   Variable,
@@ -40,6 +41,13 @@ export enum TypeKind {
  */
 export interface TypeVariable {
   kind: typeof TypeKind.Variable
+}
+
+/**
+ * A type variable that is used internally and cannot be related to other types.
+ */
+export interface TemporaryTypeVariable {
+  kind: typeof TypeKind.TemporaryVariable
 }
 
 /**
@@ -173,9 +181,10 @@ export interface SubtractionType {
   right: UnresolvedType
 }
 
-export type DeclaredType = TypeVariable | GenericType
+export type DeclaredType = TypeVariable | TemporaryTypeVariable | GenericType
 export type UnresolvedType =
   | TypeVariable
+  | TemporaryTypeVariable
   | CurriedType<UnresolvedType>
   | RefinedType<UnresolvedType>
   | RefinedTerm
@@ -191,6 +200,7 @@ export type UnresolvedType =
   | TermType
 export type ResolvedType =
   | TypeVariable
+  | TemporaryTypeVariable
   | CurriedType<ResolvedType>
   | RefinedType<ResolvedType>
   | RefinedTerm
@@ -205,6 +215,10 @@ export type Type = UnresolvedType | ResolvedType
 
 export const buildTypeVariable = (): TypeVariable => ({
   kind: TypeKind.Variable,
+})
+
+export const buildTemporaryTypeVariable = (): TemporaryTypeVariable => ({
+  kind: TypeKind.TemporaryVariable,
 })
 
 export const buildCurriedType = <T extends Type>(

--- a/src/types/type_inference/types.ts
+++ b/src/types/type_inference/types.ts
@@ -54,7 +54,7 @@ export interface TemporaryTypeVariable {
  * A curried type represents an abstraction parametrized by the `from` type and
  * returning the `to` type.
  */
-export interface CurriedType<T extends Type> {
+export interface CurriedType<T extends Type = Type> {
   kind: typeof TypeKind.Curried
   from: T
   to: T
@@ -93,7 +93,7 @@ export interface TermType {
  * A refined type represents a type alongside some predicates on values of that
  * type.
  */
-export interface RefinedType<T extends Type> {
+export interface RefinedType<T extends Type = Type> {
   kind: typeof TypeKind.Refined
   type: T
   predicates: Predicate[]
@@ -111,7 +111,7 @@ export interface RefinedTerm {
 /**
  * A property represents the mapping of a key to a value.
  */
-export type Property<T extends Type, U extends Type> = {
+export type Property<T extends Type = Type, U extends Type = Type> = {
   key: T
   value: U
 }
@@ -119,7 +119,7 @@ export type Property<T extends Type, U extends Type> = {
 /**
  * An object type represents the scope of an object (e.g. its properties).
  */
-export interface ObjectType<T extends Type, U extends Type> {
+export interface ObjectType<T extends Type = Type, U extends Type = Type> {
   kind: typeof TypeKind.Object
   properties: Property<T, U>[]
 }
@@ -128,7 +128,7 @@ export interface ObjectType<T extends Type, U extends Type> {
  * A map type represents the scope of a mapping from values of a key type to
  * values of a value type.
  */
-export interface MapType<T extends Type, U extends Type> {
+export interface MapType<T extends Type = Type, U extends Type = Type> {
   kind: typeof TypeKind.Map
   property: Property<T, U>
 }
@@ -136,7 +136,7 @@ export interface MapType<T extends Type, U extends Type> {
 /**
  * A union type represents the type of any of its parameters.
  */
-export interface UnionType<T extends Type> {
+export interface UnionType<T extends Type = Type> {
   kind: typeof TypeKind.Union
   parameters: T[]
 }
@@ -145,7 +145,7 @@ export interface UnionType<T extends Type> {
  * An intersection type represents all types that can be assigned to all of its
  * parameters.
  */
-export interface IntersectionType<T extends Type> {
+export interface IntersectionType<T extends Type = Type> {
   kind: typeof TypeKind.Intersection
   parameters: T[]
 }

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,2 +1,5 @@
 export const isNotUndefined = <T>(value: T | undefined): value is T =>
   value !== undefined
+
+export const filterUnique = <T>(list: T[]): T[] =>
+  list.filter((item, index) => list.indexOf(item) === index)

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -2,6 +2,7 @@ import {
   ConstrainedType,
   TypeConstraints,
   buildConstrainedType,
+  buildTypeConstraints,
   buildTypeVariableAssignment,
 } from '../types/type_inference/constraints'
 import {
@@ -21,10 +22,8 @@ export const buildConstrainedUnknownType = <T extends Type>(
 ): ConstrainedType<TemporaryTypeVariable, T> =>
   buildConstrainedType(buildTemporaryTypeVariable(), constraints)
 
-export const buildTypeConstraintsFromTypes = <T extends Type>(
+export const buildTypeConstraintsFromType = <T extends Type>(
   typeVariable: TypeVariable,
-  constraints: T[] = [],
+  type: T,
 ): TypeConstraints<T> =>
-  constraints.map((constraint) =>
-    buildTypeVariableAssignment([typeVariable], constraint),
-  )
+  buildTypeConstraints([buildTypeVariableAssignment([typeVariable], type)])

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -5,13 +5,11 @@ import {
   buildTypeVariableAssignment,
 } from '../types/type_inference/constraints'
 import {
-  DeclaredType,
   TemporaryTypeVariable,
   Type,
   TypeVariable,
   buildTemporaryTypeVariable,
 } from '../types/type_inference/types'
-import { unifyConstraints } from '../type_inference/constraints'
 
 export const buildUnconstrainedUnknownType = <
   T extends Type
@@ -30,15 +28,3 @@ export const buildTypeConstraintsFromTypes = <T extends Type>(
   constraints.map((constraint) =>
     buildTypeVariableAssignment([typeVariable], constraint),
   )
-
-export const reduceConstraintTypes = <
-  T extends DeclaredType | Type,
-  U extends Type
->(
-  ...constrainedTypes: ConstrainedType<T, U>[]
-): [types: T[], constraints: TypeConstraints<U>] => [
-  constrainedTypes.map((constrainedType) => constrainedType.type),
-  unifyConstraints(
-    ...constrainedTypes.map((constrainedType) => constrainedType.constraints),
-  ),
-]

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -27,7 +27,7 @@ export const buildTypeConstraintsFromTypes = <T extends Type>(
   constraints: T[] = [],
 ): TypeConstraints<T> =>
   constraints.map((constraint) =>
-    buildTypeVariableAssignment(typeVariable, constraint),
+    buildTypeVariableAssignment([typeVariable], constraint),
   )
 
 export const reduceConstraintTypes = <

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -6,9 +6,11 @@ import {
   buildTypeVariableAssignment,
 } from '../types/type_inference/constraints'
 import {
+  IntersectionType,
   TemporaryTypeVariable,
   Type,
   TypeVariable,
+  UnionType,
   buildTemporaryTypeVariable,
 } from '../types/type_inference/types'
 
@@ -27,3 +29,14 @@ export const buildTypeConstraintsFromType = <T extends Type>(
   type: T,
 ): TypeConstraints<T> =>
   buildTypeConstraints([buildTypeVariableAssignment([typeVariable], type)])
+
+export const flattenType = <T extends UnionType | IntersectionType>(
+  type: T,
+): T => ({
+  ...type,
+  parameters: type.parameters.reduce<Type[]>((parameters, parameter) => {
+    if (parameter.kind !== type.kind) return [...parameters, parameter]
+    const flattenedParameter = flattenType(parameter)
+    return [...parameters, ...flattenedParameter.parameters]
+  }, []),
+})

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -6,21 +6,22 @@ import {
 } from '../types/type_inference/constraints'
 import {
   DeclaredType,
+  TemporaryTypeVariable,
   Type,
   TypeVariable,
-  buildTypeVariable,
+  buildTemporaryTypeVariable,
 } from '../types/type_inference/types'
 import { unifyConstraints } from '../type_inference/constraints'
 
 export const buildUnconstrainedUnknownType = <
   T extends Type
->(): ConstrainedType<TypeVariable, T> =>
-  buildConstrainedType(buildTypeVariable())
+>(): ConstrainedType<TemporaryTypeVariable, T> =>
+  buildConstrainedType(buildTemporaryTypeVariable())
 
 export const buildConstrainedUnknownType = <T extends Type>(
   constraints: TypeConstraints<T>,
-): ConstrainedType<TypeVariable, T> =>
-  buildConstrainedType(buildTypeVariable(), constraints)
+): ConstrainedType<TemporaryTypeVariable, T> =>
+  buildConstrainedType(buildTemporaryTypeVariable(), constraints)
 
 export const buildTypeConstraintsFromTypes = <T extends Type>(
   typeVariable: TypeVariable,


### PR DESCRIPTION
- [x] introduce the concept of temporary type variables that aren't tracked with constraints (because they are only used internally, e.g. for unification)
- [x] fix constraints
- [x] pass state to unification (to add errors)
