### PR TITLE
[#387] Refactor code generation

### DIFF
--- a/src/analyze/file_scope.ts
+++ b/src/analyze/file_scope.ts
@@ -489,14 +489,18 @@ const handleDestructuringPattern = (
   node: DestructuringPatternNode,
 ): State => {
   if (node.aliasNode === undefined) return traverse(state, node.patternNode)
-
-  const { exportNextBindings: isExported } = state
+  const {
+    exportNextBindings: isExported,
+    nextIdentifierPatternBindingsImplicit: isImplicit,
+    importNextBindingsFrom: importedFrom,
+  } = state
   const name = getIdentifierName(node.aliasNode)
   const stateWithAlias = traverse(state, node.aliasNode)
   const stateWithBinding = addTermBinding(
     name,
-    false,
+    !!isImplicit,
     isExported,
+    importedFrom,
   )(stateWithAlias, node)
   return traverse(stateWithBinding, node.patternNode)
 }

--- a/src/check.ts
+++ b/src/check.ts
@@ -1,0 +1,28 @@
+import { GlobalScope, TypedFileScope } from './types/analyze/scopes'
+import { LogLevel, log } from './logger'
+import { buildReport, reportHasError } from './errors'
+import { Config } from './config'
+import { Report } from './types/errors/reports'
+import { analyze } from './analyze'
+import { inferTypes } from './type_inference'
+
+type CheckResult = GlobalScope<TypedFileScope> | Report
+
+export const check = async (config: Config): Promise<CheckResult> => {
+  log(config, LogLevel.Info, 'Checking', config.entry.path)
+
+  const globalScope = await analyze(config)
+  const typedGlobalScope = inferTypes(config, globalScope)
+
+  const report = buildReport(typedGlobalScope)
+  if (reportHasError(report)) return report
+
+  return typedGlobalScope
+}
+
+export const checkSuccessful = (
+  result: CheckResult,
+): result is GlobalScope<TypedFileScope> => 'kind' in result
+
+export const checkUnsuccessful = (result: CheckResult): result is Report =>
+  !checkSuccessful(result)

--- a/src/check.ts
+++ b/src/check.ts
@@ -1,28 +1,17 @@
 import { GlobalScope, TypedFileScope } from './types/analyze/scopes'
 import { LogLevel, log } from './logger'
-import { buildReport, reportHasError } from './errors'
 import { Config } from './config'
-import { Report } from './types/errors/reports'
 import { analyze } from './analyze'
 import { inferTypes } from './type_inference'
 
-type CheckResult = GlobalScope<TypedFileScope> | Report
-
-export const check = async (config: Config): Promise<CheckResult> => {
+/**
+ * Runs analysis and type inference to return a typed global scope.
+ */
+export const check = async (
+  config: Config,
+): Promise<GlobalScope<TypedFileScope>> => {
   log(config, LogLevel.Info, 'Checking', config.entry.path)
 
   const globalScope = await analyze(config)
-  const typedGlobalScope = inferTypes(config, globalScope)
-
-  const report = buildReport(typedGlobalScope)
-  if (reportHasError(report)) return report
-
-  return typedGlobalScope
+  return inferTypes(config, globalScope)
 }
-
-export const checkSuccessful = (
-  result: CheckResult,
-): result is GlobalScope<TypedFileScope> => 'kind' in result
-
-export const checkUnsuccessful = (result: CheckResult): result is Report =>
-  !checkSuccessful(result)

--- a/src/code_generation/bindings.ts
+++ b/src/code_generation/bindings.ts
@@ -1,23 +1,34 @@
 import { TermBinding, TermBindingNode } from '../types/analyze/bindings'
 
-const buildBindingName = (binding: TermBinding) =>
+/**
+ * Given a binding, generates the name representing that binding.
+ */
+export const generateBindingName = (binding: TermBinding): string =>
   `${binding.name}${binding.index}`
 
+/**
+ * Generates a declaration of all non-implicit bindings in the given set of
+ * bindings.
+ */
 export const generateDeclarations = (bindings: TermBinding[]): string => {
   const declarations = bindings
     .filter((binding) => !binding.isImplicit)
-    .map(buildBindingName)
+    .map(generateBindingName)
   if (declarations.length > 0) return `const ${declarations.join(',')}`
   return ''
 }
 
-const getBindingOfNode = (bindings: TermBinding[], node: TermBindingNode) =>
+const findBindingOfNode = (bindings: TermBinding[], node: TermBindingNode) =>
   bindings.find((binding) => binding.node === node)
 
-export const getBindingName = (
+/**
+ * Given a set of bindings and a node, finds the binding declared by the node
+ * and generates the name representing that binding.
+ */
+export const generateDeclaredBindingName = (
   bindings: TermBinding[],
   node: TermBindingNode,
 ): string | undefined => {
-  const binding = getBindingOfNode(bindings, node)
-  if (binding) return buildBindingName(binding)
+  const binding = findBindingOfNode(bindings, node)
+  if (binding) return generateBindingName(binding)
 }

--- a/src/code_generation/bindings.ts
+++ b/src/code_generation/bindings.ts
@@ -4,6 +4,7 @@ import {
   TermBindingNode,
 } from '../types/analyze/bindings'
 import { AbsolutePath } from '../types/path'
+import { getOutPath } from '../util/paths'
 
 /**
  * Given a binding, generates the name representing that binding.
@@ -12,6 +13,22 @@ export const generateBindingName = (
   binding: TermBinding,
   ignoreIndex = false,
 ): string => (ignoreIndex ? binding.name : `${binding.name}${binding.index}`)
+
+const findBindingOfNode = (bindings: TermBinding[], node: TermBindingNode) =>
+  bindings.find((binding) => binding.node === node)
+
+/**
+ * Given a set of bindings and a node, finds the binding declared by the node
+ * and generates the name representing that binding.
+ */
+export const generateDeclaredBindingName = (
+  bindings: TermBinding[],
+  node: TermBindingNode,
+  ignoreIndex = false,
+): string | undefined => {
+  const binding = findBindingOfNode(bindings, node)
+  if (binding) return generateBindingName(binding, ignoreIndex)
+}
 
 /**
  * Generates a declaration of all non-implicit bindings in the given set of
@@ -22,6 +39,18 @@ export const generateDeclarations = (bindings: TermBinding[]): string => {
     .filter((binding) => !binding.isImplicit)
     .map((binding) => generateBindingName(binding))
   if (declarations.length > 0) return `const ${declarations.join(',')}`
+  return ''
+}
+
+/**
+ * Generates export statement for all exported bindings.
+ */
+export const generateExports = (bindings: TermBinding[]): string => {
+  const exportedBindings = bindings
+    .filter((binding) => binding.isExported)
+    .map((binding) => generateBindingName(binding))
+  if (exportedBindings.length > 0)
+    return `export {${exportedBindings.join(',')}}`
   return ''
 }
 
@@ -45,32 +74,12 @@ export const generateImports = (
 const generateImport = (
   source: AbsolutePath,
   bindings: ImportedTermBinding[],
-): string => {}
-
-/**
- * Generates export statement for all exported bindings.
- */
-export const generateExports = (bindings: TermBinding[]): string => {
-  const exportedBindings = bindings
-    .filter((binding) => binding.isExported)
-    .map((binding) => generateBindingName(binding))
-  if (exportedBindings.length > 0)
-    return `export {${exportedBindings.join(',')}}`
-  return ''
-}
-
-const findBindingOfNode = (bindings: TermBinding[], node: TermBindingNode) =>
-  bindings.find((binding) => binding.node === node)
-
-/**
- * Given a set of bindings and a node, finds the binding declared by the node
- * and generates the name representing that binding.
- */
-export const generateDeclaredBindingName = (
-  bindings: TermBinding[],
-  node: TermBindingNode,
-  ignoreIndex = false,
-): string | undefined => {
-  const binding = findBindingOfNode(bindings, node)
-  if (binding) return generateBindingName(binding, ignoreIndex)
+): string => {
+  const outSource = getOutPath(source)
+  const aliases = bindings
+    .map(({ name, originalName }) =>
+      originalName ? `${name} as ${originalName}` : name,
+    )
+    .join(',')
+  return `import {${aliases}} from '${outSource.path}'`
 }

--- a/src/code_generation/bindings.ts
+++ b/src/code_generation/bindings.ts
@@ -69,7 +69,8 @@ const findBindingOfNode = (bindings: TermBinding[], node: TermBindingNode) =>
 export const generateDeclaredBindingName = (
   bindings: TermBinding[],
   node: TermBindingNode,
+  ignoreIndex = false,
 ): string | undefined => {
   const binding = findBindingOfNode(bindings, node)
-  if (binding) return generateBindingName(binding)
+  if (binding) return generateBindingName(binding, ignoreIndex)
 }

--- a/src/code_generation/bindings.ts
+++ b/src/code_generation/bindings.ts
@@ -1,0 +1,12 @@
+import { TermBinding } from '../types/analyze/bindings'
+
+const buildBindingName = (binding: TermBinding): string =>
+  `${binding.name}${binding.index}`
+
+export const generateDeclarations = (bindings: TermBinding[]): string => {
+  const declarations = bindings
+    .filter((binding) => !binding.isImplicit)
+    .map(buildBindingName)
+  if (declarations.length > 0) return `const ${declarations.join(',')}`
+  return ''
+}

--- a/src/code_generation/bindings.ts
+++ b/src/code_generation/bindings.ts
@@ -2,7 +2,6 @@ import {
   ImportedTermBinding,
   TermBinding,
   TermBindingNode,
-  isImportedBinding,
 } from '../types/analyze/bindings'
 import { AbsolutePath } from '../types/path'
 

--- a/src/code_generation/bindings.ts
+++ b/src/code_generation/bindings.ts
@@ -1,6 +1,6 @@
-import { TermBinding } from '../types/analyze/bindings'
+import { TermBinding, TermBindingNode } from '../types/analyze/bindings'
 
-const buildBindingName = (binding: TermBinding): string =>
+const buildBindingName = (binding: TermBinding) =>
   `${binding.name}${binding.index}`
 
 export const generateDeclarations = (bindings: TermBinding[]): string => {
@@ -9,4 +9,15 @@ export const generateDeclarations = (bindings: TermBinding[]): string => {
     .map(buildBindingName)
   if (declarations.length > 0) return `const ${declarations.join(',')}`
   return ''
+}
+
+const getBindingOfNode = (bindings: TermBinding[], node: TermBindingNode) =>
+  bindings.find((binding) => binding.node === node)
+
+export const getBindingName = (
+  bindings: TermBinding[],
+  node: TermBindingNode,
+): string | undefined => {
+  const binding = getBindingOfNode(bindings, node)
+  if (binding) return buildBindingName(binding)
 }

--- a/src/code_generation/bindings.ts
+++ b/src/code_generation/bindings.ts
@@ -1,4 +1,10 @@
-import { TermBinding, TermBindingNode } from '../types/analyze/bindings'
+import {
+  ImportedTermBinding,
+  TermBinding,
+  TermBindingNode,
+  isImportedBinding,
+} from '../types/analyze/bindings'
+import { AbsolutePath } from '../types/path'
 
 /**
  * Given a binding, generates the name representing that binding.
@@ -15,6 +21,40 @@ export const generateDeclarations = (bindings: TermBinding[]): string => {
     .filter((binding) => !binding.isImplicit)
     .map(generateBindingName)
   if (declarations.length > 0) return `const ${declarations.join(',')}`
+  return ''
+}
+
+/**
+ * Generates import statements for all imported bindings.
+ */
+export const generateImports = (
+  dependencies: AbsolutePath[],
+  bindings: ImportedTermBinding[],
+): string => {
+  return dependencies
+    .map((source) =>
+      generateImport(
+        source,
+        bindings.filter((binding) => binding.file === source),
+      ),
+    )
+    .join(';')
+}
+
+const generateImport = (
+  source: AbsolutePath,
+  bindings: ImportedTermBinding[],
+): string => {}
+
+/**
+ * Generates export statement for all exported bindings.
+ */
+export const generateExports = (bindings: TermBinding[]): string => {
+  const exportedBindings = bindings
+    .filter((binding) => binding.isExported)
+    .map(generateBindingName)
+  if (exportedBindings.length > 0)
+    return `export {${exportedBindings.join(',')}}`
   return ''
 }
 

--- a/src/code_generation/bindings.ts
+++ b/src/code_generation/bindings.ts
@@ -8,8 +8,10 @@ import { AbsolutePath } from '../types/path'
 /**
  * Given a binding, generates the name representing that binding.
  */
-export const generateBindingName = (binding: TermBinding): string =>
-  `${binding.name}${binding.index}`
+export const generateBindingName = (
+  binding: TermBinding,
+  ignoreIndex = false,
+): string => (ignoreIndex ? binding.name : `${binding.name}${binding.index}`)
 
 /**
  * Generates a declaration of all non-implicit bindings in the given set of
@@ -18,7 +20,7 @@ export const generateBindingName = (binding: TermBinding): string =>
 export const generateDeclarations = (bindings: TermBinding[]): string => {
   const declarations = bindings
     .filter((binding) => !binding.isImplicit)
-    .map(generateBindingName)
+    .map((binding) => generateBindingName(binding))
   if (declarations.length > 0) return `const ${declarations.join(',')}`
   return ''
 }
@@ -51,7 +53,7 @@ const generateImport = (
 export const generateExports = (bindings: TermBinding[]): string => {
   const exportedBindings = bindings
     .filter((binding) => binding.isExported)
-    .map(generateBindingName)
+    .map((binding) => generateBindingName(binding))
   if (exportedBindings.length > 0)
     return `export {${exportedBindings.join(',')}}`
   return ''

--- a/src/code_generation/constants.ts
+++ b/src/code_generation/constants.ts
@@ -1,3 +1,0 @@
-const UTILS_MODULE = 'codeGeneration'
-export const CURRY_FUNCTION = `${UTILS_MODULE}.curry`
-export const RESOLVE_ABSTRACTION_BRANCH_FUNCTION = `${UTILS_MODULE}.resolveAbstractionBranch`

--- a/src/code_generation/constants.ts
+++ b/src/code_generation/constants.ts
@@ -1,0 +1,3 @@
+const UTILS_MODULE = 'codeGeneration'
+export const CURRY_FUNCTION = `${UTILS_MODULE}.curry`
+export const RESOLVE_ABSTRACTION_BRANCH_FUNCTION = `${UTILS_MODULE}.resolveAbstractionBranch`

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -31,6 +31,11 @@ export const generateAbstractionBranch = (
 export const generateAccess = (name: string, value: string): string =>
   `${name}[${value}]`
 
+export const generateApplication = (value: string, args: string[]): string => {
+  const joinedArgs = args.join(',')
+  return `${value}(${joinedArgs})`
+}
+
 export const generateAssignment = (pattern: string, value: string): string => {
   const [resolvedPattern, identifiers, defaults] = resolvePattern(pattern)
   return patternMatch(resolvedPattern, identifiers, defaults, value)

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -51,3 +51,6 @@ export const generateBlock = (
 }
 
 export const generateCase = resolveAbstractionBranch
+
+export const generateEliseIf = (condition: string, body: string): string =>
+  `else if(${condition}){return ${body}}`

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -139,6 +139,11 @@ export const generateShorthandAccessIdentifier = (name: string): string =>
 export const generateShorthandMember = (name: string, value: string): string =>
   `${name}:${value}`
 
+export const generateShorthandMemberPattern = (
+  name: string,
+  value: string,
+): string => `"${name}":"${value}"`
+
 export const generateSpread = (value: string): string => `...${value}`
 
 export const generateString = (content: string): string => `\`${content}\``

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -1,0 +1,17 @@
+import { curry, patternMatch, resolveAbstractionBranch } from './lib'
+import { resolvePattern } from './patterns'
+
+export const generateAbstraction = (branches: string[]): string =>
+  curry(resolveAbstractionBranch(branches))
+
+export const generateAbstractionBranch = (
+  parameters: string[],
+  restParameter: string | undefined,
+  body: string,
+): string => {
+  const [pattern, identifiers, defaults] = resolvePattern(
+    parameters,
+    restParameter,
+  )
+  return `[${pattern},${defaults},${patternMatch(identifiers, body)}]`
+}

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -62,5 +62,8 @@ export const generateGenerator = (
   return `${value}.map((${name})=>!${condition} ? "${INTERNAL_TEMP_TOKEN}" : `
 }
 
+export const generateIdentifierPattern = (name: string): string =>
+  `"${INTERNAL_TEMP_TOKEN}${name}"`
+
 export const generateMember = (key: string, value: string): string =>
   `[${key}]:${value}`

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -125,5 +125,8 @@ export const generateListComprehension = (
 export const generateMember = (key: string, value: string): string =>
   `[${key}]:${value}`
 
+export const generatePipeline = (name: string, value: string): string =>
+  `${name}(${value})`
+
 export const generateStruct = (members: string[]): string =>
   `{${members.join(',')}}`

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -130,5 +130,7 @@ export const generateProgram = (
   return `${UTILS_IMPORT};${imports};${declarations};${joinedTerms};${exports}`
 }
 
+export const generateReturn = (value: string): string => `return ${value}`
+
 export const generateStruct = (members: string[]): string =>
   `{${members.join(',')}}`

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -7,7 +7,7 @@ import {
   resolveAbstractionBranch,
 } from './lib'
 
-const ARGUMENTS_NAME = 'args'
+const ARGUMENTS_NAME = '$ARGS'
 const INTERNAL_TEMP_TOKEN = '$INTERNAL_TEMP_TOKEN'
 const TRANSFORM_PLACEHOLDER_ARGUMENT = '$TRANSFORM_PLACEHOLDER_ARGUMENT'
 
@@ -136,6 +136,8 @@ export const generateShorthandAccessIdentifier = (name: string): string =>
   `'${name}'`
 
 export const generateSpread = (value: string): string => `...${value}`
+
+export const generateString = (content: string): string => `\`${content}\``
 
 export const generateStruct = (members: string[]): string =>
   `{${members.join(',')}}`

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -86,5 +86,11 @@ export const generateIf = (
   }})()`
 }
 
+export const generateInfixApplication = (
+  value: string,
+  left: string,
+  right: string,
+): string => `${value}(${left},${right})`
+
 export const generateMember = (key: string, value: string): string =>
   `[${key}]:${value}`

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -111,12 +111,10 @@ export const generateListComprehension = (
   }).filter(e=>e!=="${INTERNAL_TEMP_TOKEN}")`
 
 export const generateListPattern = (
-  parameters: string[],
-  restParameter?: string,
+  elements: string[],
+  rest?: string,
 ): string =>
-  restParameter
-    ? `[${parameters.join(',')},...${restParameter}]`
-    : `[${parameters.join(',')}]`
+  rest ? `[${elements.join(',')},...${rest}]` : `[${elements.join(',')}]`
 
 export const generateMember = (key: string, value: string): string =>
   `[${key}]:${value}`
@@ -150,6 +148,12 @@ export const generateString = (content: string): string => `\`${content}\``
 
 export const generateStruct = (members: string[]): string =>
   `{${members.join(',')}}`
+
+export const generateStructPattern = (
+  members: string[],
+  rest?: string,
+): string =>
+  rest ? `{${members.join(',')},...${rest}}` : `{${members.join(',')}}`
 
 export const generateWhen = (
   patterns: GeneratedPattern[],

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -95,5 +95,13 @@ export const generateInfixApplication = (
 export const generateList = (elements: string[]): string =>
   `[${elements.join(',')}]`
 
+export const generateListComprehension = (
+  generators: string[],
+  body: string,
+): string =>
+  `${generators}${body}${')'.repeat(generators.length)}.flat(${
+    generators.length - 1
+  }).filter(e=>e!=="${INTERNAL_TEMP_TOKEN}")`
+
 export const generateMember = (key: string, value: string): string =>
   `[${key}]:${value}`

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -9,15 +9,8 @@ import {
 
 const ARGUMENTS_NAME = '$ARGS'
 const INTERNAL_TEMP_TOKEN = '$INTERNAL_TEMP_TOKEN'
+const TRANSFORM_IDENTIFIER_PATTERN = '$TRANSFORM_IDENTIFIER_PATTERN'
 const TRANSFORM_PLACEHOLDER_ARGUMENT = '$TRANSFORM_PLACEHOLDER_ARGUMENT'
-
-const generateListPattern = (
-  parameters: string[],
-  restParameter: string | undefined,
-) =>
-  restParameter
-    ? `[${parameters.join(',')},...${restParameter}]`
-    : `[${parameters.join(',')}]`
 
 export const generateAbstraction = (branches: string[]): string =>
   curry(ARGUMENTS_NAME, resolveAbstractionBranch(ARGUMENTS_NAME, branches))
@@ -91,8 +84,8 @@ export const generateGenerator = (
     condition ? `!${condition} ? "${INTERNAL_TEMP_TOKEN}" : ` : ''
   }`
 
-export const generateIdentifierPattern = (name: string): string =>
-  `"${INTERNAL_TEMP_TOKEN}${name}"`
+export const generateIdentifierPattern = (): string =>
+  `"${TRANSFORM_IDENTIFIER_PATTERN}"`
 
 export const generateIf = (
   condition: string,
@@ -116,6 +109,14 @@ export const generateListComprehension = (
   `${generators}${body}${')'.repeat(generators.length)}.flat(${
     generators.length - 1
   }).filter(e=>e!=="${INTERNAL_TEMP_TOKEN}")`
+
+export const generateListPattern = (
+  parameters: string[],
+  restParameter?: string,
+): string =>
+  restParameter
+    ? `[${parameters.join(',')},...${restParameter}]`
+    : `[${parameters.join(',')}]`
 
 export const generateMember = (key: string, value: string): string =>
   `[${key}]:${value}`

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -1,4 +1,11 @@
-import { curry, patternMatch, resolveAbstractionBranch } from './lib'
+import {
+  curry,
+  patternMatch,
+  patternMatchForAbstraction,
+  resolveAbstractionBranch,
+} from './lib'
+import { ScopeWithTerms } from '../types/analyze/scopes'
+import { generateDeclarations } from './bindings'
 import { resolvePattern } from './patterns'
 
 export const generateAbstraction = (branches: string[]): string =>
@@ -10,8 +17,33 @@ export const generateAbstractionBranch = (
   body: string,
 ): string => {
   const [pattern, identifiers, defaults] = resolvePattern(
-    parameters,
-    restParameter,
+    restParameter
+      ? `[${parameters.join(',')},...${restParameter}]`
+      : `[${parameters.join(',')}]`,
   )
-  return `[${pattern},${defaults},${patternMatch(identifiers, body)}]`
+  return `[${pattern},${defaults},${patternMatchForAbstraction(
+    identifiers,
+    body,
+  )}]`
+}
+
+export const generateAccess = (name: string, value: string): string =>
+  `${name}[${value}]`
+
+export const generateAssignment = (pattern: string, value: string): string => {
+  const [resolvedPattern, identifiers, defaults] = resolvePattern(pattern)
+  return patternMatch(resolvedPattern, identifiers, defaults, value)
+}
+
+export const generateBlock = (
+  scope: ScopeWithTerms,
+  terms: string[],
+  endsWithReturn: boolean,
+): string => {
+  const declarations = generateDeclarations(scope.terms)
+  const returnValue = terms.pop()
+  const explicitReturn = endsWithReturn ? '' : 'return '
+  return `(()=>{${declarations};${terms.join(
+    ';',
+  )};${explicitReturn}${returnValue}})()`
 }

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -135,6 +135,9 @@ export const generateReturn = (value: string): string => `return ${value}`
 export const generateShorthandAccessIdentifier = (name: string): string =>
   `'${name}'`
 
+export const generateShorthandMember = (name: string, value: string): string =>
+  `${name}:${value}`
+
 export const generateSpread = (value: string): string => `...${value}`
 
 export const generateString = (content: string): string => `\`${content}\``

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -1,5 +1,6 @@
 import { GeneratedPattern, GeneratedPatterns } from './patterns'
 import {
+  UTILS_IMPORT,
   curry,
   patternMatch,
   patternMatchForAbstraction,
@@ -118,6 +119,16 @@ export const generateListComprehension = (
 
 export const generateMember = (key: string, value: string): string =>
   `[${key}]:${value}`
+
+export const generateProgram = (
+  declarations: string,
+  imports: string,
+  exports: string,
+  terms: string[],
+): string => {
+  const joinedTerms = terms.join(';')
+  return `${UTILS_IMPORT};${imports};${declarations};${joinedTerms};${exports}`
+}
 
 export const generateStruct = (members: string[]): string =>
   `{${members.join(',')}}`

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -105,12 +105,6 @@ export const generateIf = (
   }})()`
 }
 
-export const generateInfixApplication = (
-  value: string,
-  left: string,
-  right: string,
-): string => `${value}(${left},${right})`
-
 export const generateList = (elements: string[]): string =>
   `[${elements.join(',')}]`
 
@@ -124,9 +118,6 @@ export const generateListComprehension = (
 
 export const generateMember = (key: string, value: string): string =>
   `[${key}]:${value}`
-
-export const generatePipeline = (name: string, value: string): string =>
-  `${name}(${value})`
 
 export const generateStruct = (members: string[]): string =>
   `{${members.join(',')}}`

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -137,3 +137,14 @@ export const generateShorthandAccessIdentifier = (name: string): string =>
 
 export const generateStruct = (members: string[]): string =>
   `{${members.join(',')}}`
+
+export const generateWhen = (
+  patterns: GeneratedPattern[],
+  body: string,
+): string =>
+  patterns
+    .map(
+      ([pattern, identifiersPattern, defaultsPattern]) =>
+        `[${pattern},${defaultsPattern},(match)=>{const [${identifiersPattern}]=match;return ${body}}]`,
+    )
+    .join(',')

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -54,3 +54,6 @@ export const generateCase = resolveAbstractionBranch
 
 export const generateEliseIf = (condition: string, body: string): string =>
   `else if(${condition}){return ${body}}`
+
+export const generateMember = (key: string, value: string): string =>
+  `[${key}]:${value}`

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -8,8 +8,10 @@ import { ScopeWithTerms } from '../types/analyze/scopes'
 import { generateDeclarations } from './bindings'
 import { resolvePattern } from './patterns'
 
+const ARGUMENTS_NAME = 'args'
+
 export const generateAbstraction = (branches: string[]): string =>
-  curry(resolveAbstractionBranch(branches))
+  curry(ARGUMENTS_NAME, resolveAbstractionBranch(ARGUMENTS_NAME, branches))
 
 export const generateAbstractionBranch = (
   parameters: string[],
@@ -47,3 +49,5 @@ export const generateBlock = (
     ';',
   )};${explicitReturn}${returnValue}})()`
 }
+
+export const generateCase = resolveAbstractionBranch

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -8,6 +8,7 @@ import { resolvePattern } from './patterns'
 
 const ARGUMENTS_NAME = 'args'
 const INTERNAL_TEMP_TOKEN = '$INTERNAL_TEMP_TOKEN'
+const TRANSFORM_PLACEHOLDER_ARGUMENT = '$TRANSFORM_PLACEHOLDER_ARGUMENT'
 
 export const generateAbstraction = (branches: string[]): string =>
   curry(ARGUMENTS_NAME, resolveAbstractionBranch(ARGUMENTS_NAME, branches))
@@ -35,6 +36,9 @@ export const generateApplication = (value: string, args: string[]): string => {
   const joinedArgs = args.join(',')
   return `${value}(${joinedArgs})`
 }
+
+export const generateArgument = (value?: string): string =>
+  value ? value : `"${TRANSFORM_PLACEHOLDER_ARGUMENT}"`
 
 export const generateAssignment = (pattern: string, value: string): string => {
   const [resolvedPattern, identifiers, defaults] = resolvePattern(pattern)

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -92,5 +92,8 @@ export const generateInfixApplication = (
   right: string,
 ): string => `${value}(${left},${right})`
 
+export const generateList = (elements: string[]): string =>
+  `[${elements.join(',')}]`
+
 export const generateMember = (key: string, value: string): string =>
   `[${key}]:${value}`

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -4,11 +4,10 @@ import {
   patternMatchForAbstraction,
   resolveAbstractionBranch,
 } from './lib'
-import { ScopeWithTerms } from '../types/analyze/scopes'
-import { generateDeclarations } from './bindings'
 import { resolvePattern } from './patterns'
 
 const ARGUMENTS_NAME = 'args'
+const INTERNAL_TEMP_TOKEN = '$INTERNAL_TEMP_TOKEN'
 
 export const generateAbstraction = (branches: string[]): string =>
   curry(ARGUMENTS_NAME, resolveAbstractionBranch(ARGUMENTS_NAME, branches))
@@ -38,11 +37,10 @@ export const generateAssignment = (pattern: string, value: string): string => {
 }
 
 export const generateBlock = (
-  scope: ScopeWithTerms,
+  declarations: string,
   terms: string[],
   endsWithReturn: boolean,
 ): string => {
-  const declarations = generateDeclarations(scope.terms)
   const returnValue = terms.pop()
   const explicitReturn = endsWithReturn ? '' : 'return '
   return `(()=>{${declarations};${terms.join(
@@ -54,6 +52,15 @@ export const generateCase = resolveAbstractionBranch
 
 export const generateEliseIf = (condition: string, body: string): string =>
   `else if(${condition}){return ${body}}`
+
+export const generateGenerator = (
+  name: string,
+  value: string,
+  condition?: string,
+): string => {
+  if (condition === undefined) return `${value}.map((${name})=>`
+  return `${value}.map((${name})=>!${condition} ? "${INTERNAL_TEMP_TOKEN}" : `
+}
 
 export const generateMember = (key: string, value: string): string =>
   `[${key}]:${value}`

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -124,3 +124,6 @@ export const generateListComprehension = (
 
 export const generateMember = (key: string, value: string): string =>
   `[${key}]:${value}`
+
+export const generateStruct = (members: string[]): string =>
+  `{${members.join(',')}}`

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -132,5 +132,8 @@ export const generateProgram = (
 
 export const generateReturn = (value: string): string => `return ${value}`
 
+export const generateShorthandAccessIdentifier = (name: string): string =>
+  `'${name}'`
+
 export const generateStruct = (members: string[]): string =>
   `{${members.join(',')}}`

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -57,13 +57,25 @@ export const generateGenerator = (
   name: string,
   value: string,
   condition?: string,
-): string => {
-  if (condition === undefined) return `${value}.map((${name})=>`
-  return `${value}.map((${name})=>!${condition} ? "${INTERNAL_TEMP_TOKEN}" : `
-}
+): string =>
+  `${value}.map((${name})=>${
+    condition ? `!${condition} ? "${INTERNAL_TEMP_TOKEN}" : ` : ''
+  }`
 
 export const generateIdentifierPattern = (name: string): string =>
   `"${INTERNAL_TEMP_TOKEN}${name}"`
+
+export const generateIf = (
+  condition: string,
+  body: string,
+  alternativeBodies: string[],
+  alternativeBody?: string,
+): string => {
+  const joinedAlternativeBodies = alternativeBodies.join('')
+  return `(()=>{if(${condition}){return ${body}}${joinedAlternativeBodies}${
+    alternativeBody ? `else{return ${alternativeBody}}` : ''
+  }})()`
+}
 
 export const generateMember = (key: string, value: string): string =>
   `[${key}]:${value}`

--- a/src/code_generation/generators.ts
+++ b/src/code_generation/generators.ts
@@ -135,6 +135,8 @@ export const generateReturn = (value: string): string => `return ${value}`
 export const generateShorthandAccessIdentifier = (name: string): string =>
   `'${name}'`
 
+export const generateSpread = (value: string): string => `...${value}`
+
 export const generateStruct = (members: string[]): string =>
   `{${members.join(',')}}`
 

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -1,4 +1,8 @@
 import { AbstractionNode, SyntaxType } from 'tree-sitter-tony'
+import {
+  CURRY_FUNCTION,
+  RESOLVE_ABSTRACTION_BRANCH_FUNCTION,
+} from './constants'
 import { Emit, buildFileEmit } from '../types/emit'
 import { GlobalScope, TypedFileScope } from '../types/analyze/scopes'
 import { LogLevel, log } from '../logger'
@@ -226,8 +230,5 @@ const handleAbstraction = (typedNode: TypedNode<AbstractionNode>): string => {
     .map((branch) => traverse(branch))
     .join(',')
 
-  return (
-    'stdlib.Curry.perform((...args)=>' +
-    `stdlib.ResolveAbstractionBranch.perform(args,[${branches}]))`
-  )
+  return `${CURRY_FUNCTION}((...args) => ${RESOLVE_ABSTRACTION_BRANCH_FUNCTION}(args, [${branches}]))`
 }

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -236,6 +236,10 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
       throw new NotImplementedError(
         'Tony cannot generate code for right sections yet.',
       )
+    case SyntaxType.ShorthandAccessIdentifier:
+      throw new NotImplementedError(
+        'Tony cannot generate code for shorthand access identifiers yet.',
+      )
     case SyntaxType.ShorthandMemberPattern:
       throw new NotImplementedError(
         'Tony cannot generate code for shorthand member patterns yet.',

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -287,8 +287,9 @@ const handleAbstractionBranch = (
   state: State,
   typedNode: TypedNode<AbstractionBranchNode>,
 ): string => {
-  const parameters = resolvePatterns(typedNode.elementNodes)
-  const restParameter = typedNode.restNode && resolvePattern(typedNode.restNode)
+  const parameters = resolvePatterns(state.scopes[0], typedNode.elementNodes)
+  const restParameter =
+    typedNode.restNode && resolvePattern(state.scopes[0], typedNode.restNode)
   const body = traverse(state, typedNode.bodyNode)
   return generateAbstractionBranch(parameters, restParameter, body)
 }
@@ -325,7 +326,7 @@ const handleAssignment = (
   state: State,
   typedNode: TypedNode<AssignmentNode>,
 ): string => {
-  const pattern = resolvePattern(typedNode.patternNode)
+  const pattern = resolvePattern(state.scopes[0], typedNode.patternNode)
   const value = traverse(state, typedNode.valueNode)
   return generateAssignment(pattern, value)
 }

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -52,7 +52,7 @@ import {
   generateDeclarations,
   generateDeclaredBindingName,
 } from './bindings'
-import { resolvePattern, resolvePatterns } from './patterns'
+import { generatePattern, generatePatterns } from './patterns'
 import { Config } from '../config'
 import { TermNode } from '../types/nodes'
 import { TypedNode } from '../types/type_inference/nodes'
@@ -287,9 +287,9 @@ const handleAbstractionBranch = (
   state: State,
   typedNode: TypedNode<AbstractionBranchNode>,
 ): string => {
-  const parameters = resolvePatterns(state.scopes[0], typedNode.elementNodes)
+  const parameters = generatePatterns(state.scopes[0], typedNode.elementNodes)
   const restParameter =
-    typedNode.restNode && resolvePattern(state.scopes[0], typedNode.restNode)
+    typedNode.restNode && generatePattern(state.scopes[0], typedNode.restNode)
   const body = traverse(state, typedNode.bodyNode)
   return generateAbstractionBranch(parameters, restParameter, body)
 }
@@ -326,7 +326,7 @@ const handleAssignment = (
   state: State,
   typedNode: TypedNode<AssignmentNode>,
 ): string => {
-  const pattern = resolvePattern(state.scopes[0], typedNode.patternNode)
+  const pattern = generatePattern(state.scopes[0], typedNode.patternNode)
   const value = traverse(state, typedNode.valueNode)
   return generateAssignment(pattern, value)
 }

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -5,6 +5,7 @@ import {
   AssignmentNode,
   BlockNode,
   CaseNode,
+  ElseIfNode,
   SyntaxType,
 } from 'tree-sitter-tony'
 import { Emit, buildFileEmit } from '../types/emit'
@@ -25,6 +26,7 @@ import {
   generateAssignment,
   generateBlock,
   generateCase,
+  generateEliseIf,
 } from './generators'
 import { safeApply, traverseScopes } from '../util/traverse'
 import { Config } from '../config'
@@ -123,9 +125,7 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
         'Tony cannot generate code for destructuring patterns yet.',
       )
     case SyntaxType.ElseIf:
-      throw new NotImplementedError(
-        'Tony cannot generate code for else ifs yet.',
-      )
+      return handleElseIf(state, typedNode as TypedNode<ElseIfNode>)
     case SyntaxType.Enum:
       throw new NotImplementedError('Tony cannot generate code for enums yet.')
     case SyntaxType.EnumValue:
@@ -341,4 +341,13 @@ const handleCase = (state: State, typedNode: TypedNode<CaseNode>): string => {
   const branches = typedNode.whenNodes.map((branch) => traverse(state, branch))
   const elseBranch = traverse(state, typedNode.elseNode)
   return generateCase(value, branches, elseBranch)
+}
+
+const handleElseIf = (
+  state: State,
+  typedNode: TypedNode<ElseIfNode>,
+): string => {
+  const condition = traverse(state, typedNode.conditionNode)
+  const body = traverse(state, typedNode.bodyNode)
+  return generateEliseIf(condition, body)
 }

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -3,6 +3,7 @@ import {
   AbstractionNode,
   AccessNode,
   ApplicationNode,
+  ArgumentNode,
   AssignmentNode,
   BlockNode,
   CaseNode,
@@ -31,6 +32,7 @@ import {
   generateAbstractionBranch,
   generateAccess,
   generateApplication,
+  generateArgument,
   generateAssignment,
   generateBlock,
   generateCase,
@@ -124,9 +126,7 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
     case SyntaxType.Application:
       return handleApplication(state, typedNode as TypedNode<ApplicationNode>)
     case SyntaxType.Argument:
-      throw new NotImplementedError(
-        'Tony cannot generate code for arguments yet.',
-      )
+      return handleArgument(state, typedNode as TypedNode<ArgumentNode>)
     case SyntaxType.Assignment:
       return handleAssignment(state, typedNode as TypedNode<AssignmentNode>)
     case SyntaxType.Block:
@@ -345,6 +345,14 @@ const handleApplication = (
     traverse(state, argument),
   )
   return generateApplication(value, args)
+}
+
+const handleArgument = (
+  state: State,
+  typedNode: TypedNode<ArgumentNode>,
+): string => {
+  const value = safeApply(traverse)(state, typedNode.valueNode)
+  return generateArgument(value)
 }
 
 const handleAssignment = (

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -11,7 +11,7 @@ import { LogLevel, log } from '../logger'
 import { NotImplementedError, assert } from '../types/errors/internal'
 import { filterFileScopeByTermScopes, findScopeOfNode } from '../util/scopes'
 import { Config } from '../config'
-import { TermNode } from '../types/nodes'
+import { TermNodeWithoutError } from '../types/nodes'
 import { TypedNode } from '../types/type_inference/nodes'
 import { generateAbstraction } from './util'
 import { traverseScopes } from '../util/traverse'
@@ -69,19 +69,20 @@ const nest = <T extends NestingTermNode>(
   return callback(nestedState, typedNode)
 }
 
-const traverse = (state: State, typedNode: TypedNode<TermNode>): string =>
+const traverse = (
+  state: State,
+  typedNode: TypedNode<TermNodeWithoutError>,
+): string =>
   traverseScopes(
     typedNode.node,
     () => handleNode(state, typedNode),
     () => nest(state, typedNode as TypedNode<NestingTermNode>, handleNode),
   )
 
-const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
-  assert(
-    typedNode.node.type !== SyntaxType.ERROR,
-    'Code generation should not be run on scopes that include errors.',
-  )
-
+const handleNode = (
+  state: State,
+  typedNode: TypedNode<TermNodeWithoutError>,
+): string => {
   switch (typedNode.node.type) {
     case SyntaxType.Abstraction:
       return handleAbstraction(state, typedNode as TypedNode<AbstractionNode>)

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -1,8 +1,4 @@
 import { AbstractionNode, SyntaxType } from 'tree-sitter-tony'
-import {
-  CURRY_FUNCTION,
-  RESOLVE_ABSTRACTION_BRANCH_FUNCTION,
-} from './constants'
 import { Emit, buildFileEmit } from '../types/emit'
 import { GlobalScope, TypedFileScope } from '../types/analyze/scopes'
 import { LogLevel, log } from '../logger'
@@ -10,6 +6,7 @@ import { NotImplementedError, assert } from '../types/errors/internal'
 import { Config } from '../config'
 import { TermNode } from '../types/nodes'
 import { TypedNode } from '../types/type_inference/nodes'
+import { generateAbstraction } from './util'
 
 export const generateCode = (
   config: Config,
@@ -226,9 +223,6 @@ const traverse = (typedNode: TypedNode<TermNode>): string => {
 }
 
 const handleAbstraction = (typedNode: TypedNode<AbstractionNode>): string => {
-  const branches = typedNode.branchNodes
-    .map((branch) => traverse(branch))
-    .join(',')
-
-  return `${CURRY_FUNCTION}((...args) => ${RESOLVE_ABSTRACTION_BRANCH_FUNCTION}(args, [${branches}]))`
+  const branches = typedNode.branchNodes.map((branch) => traverse(branch))
+  return generateAbstraction(branches)
 }

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -20,6 +20,7 @@ import {
   PipelineNode,
   PrefixApplicationNode,
   ProgramNode,
+  ReturnNode,
   StructNode,
   SyntaxType,
 } from 'tree-sitter-tony'
@@ -51,6 +52,7 @@ import {
   generateListComprehension,
   generateMember,
   generateProgram,
+  generateReturn,
   generateStruct,
 } from './generators'
 import {
@@ -236,9 +238,7 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
     case SyntaxType.Regex:
       return typedNode.node.text
     case SyntaxType.Return:
-      throw new NotImplementedError(
-        'Tony cannot generate code for returns yet.',
-      )
+      return handleReturn(state, typedNode as TypedNode<ReturnNode>)
     case SyntaxType.RightSection:
       throw new NotImplementedError(
         'Tony cannot generate code for right sections yet.',
@@ -467,6 +467,14 @@ const handleProgram = (
   )
   const exports = generateExports(scope.terms)
   return generateProgram(declarations, imports, exports, terms)
+}
+
+const handleReturn = (
+  state: State,
+  typedNode: TypedNode<ReturnNode>,
+): string => {
+  const value = traverse(state, typedNode.valueNode)
+  return generateReturn(value)
 }
 
 const handleStruct = (

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -23,6 +23,7 @@ import {
   RawStringNode,
   ReturnNode,
   ShorthandAccessIdentifierNode,
+  ShorthandMemberNode,
   SpreadNode,
   StringNode,
   StructNode,
@@ -61,6 +62,7 @@ import {
   generateProgram,
   generateReturn,
   generateShorthandAccessIdentifier,
+  generateShorthandMember,
   generateSpread,
   generateString,
   generateStruct,
@@ -255,13 +257,9 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
         typedNode as TypedNode<ShorthandAccessIdentifierNode>,
       )
     case SyntaxType.ShorthandMemberIdentifier:
-      throw new NotImplementedError(
-        'Tony cannot generate code for shorthand member identifiers yet.',
-      )
+      return typedNode.node.text
     case SyntaxType.ShorthandMember:
-      throw new NotImplementedError(
-        'Tony cannot generate code for shorthand members yet.',
-      )
+      return handleShorthandMember(typedNode as TypedNode<ShorthandMemberNode>)
     case SyntaxType.Spread:
       return handleSpread(state, typedNode as TypedNode<SpreadNode>)
     case SyntaxType.String:
@@ -484,10 +482,21 @@ const handleReturn = (
 const handleShorthandAccessIdentifier = (
   typedNode: TypedNode<ShorthandAccessIdentifierNode>,
 ): string => {
-  const name = generateBindingName(
-    (typedNode as TypedNode<ShorthandAccessIdentifierNode>).binding,
-  )
+  const name = typedNode.node.text
   return generateShorthandAccessIdentifier(name)
+}
+
+const handleShorthandMember = (
+  typedNode: TypedNode<ShorthandMemberNode>,
+): string => {
+  const name = generateBindingName(
+    (typedNode as TypedNode<ShorthandMemberNode>).binding,
+    true,
+  )
+  const value = generateBindingName(
+    (typedNode as TypedNode<ShorthandMemberNode>).binding,
+  )
+  return generateShorthandMember(name, value)
 }
 
 const handleSpread = (

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -15,6 +15,7 @@ import {
   IfNode,
   InfixApplicationNode,
   InterpolationNode,
+  ListNode,
   MemberNode,
   SyntaxType,
 } from 'tree-sitter-tony'
@@ -43,6 +44,7 @@ import {
   generateIdentifierPattern,
   generateIf,
   generateInfixApplication,
+  generateList,
   generateMember,
 } from './generators'
 import {
@@ -204,7 +206,7 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
         'Tony cannot generate code for left sections yet.',
       )
     case SyntaxType.List:
-      throw new NotImplementedError('Tony cannot generate code for lists yet.')
+      return handleList(state, typedNode as TypedNode<ListNode>)
     case SyntaxType.ListComprehension:
       throw new NotImplementedError(
         'Tony cannot generate code for list comprehensions yet.',
@@ -443,6 +445,13 @@ const handleInfixApplication = (
   const left = traverse(state, typedNode.leftNode)
   const right = traverse(state, typedNode.rightNode)
   return generateInfixApplication(value, left, right)
+}
+
+const handleList = (state: State, typedNode: TypedNode<ListNode>): string => {
+  const elements = typedNode.elementNodes.map((element) =>
+    traverse(state, element),
+  )
+  return generateList(elements)
 }
 
 const handleMember = (

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -10,6 +10,7 @@ import {
   GeneratorNode,
   IdentifierNode,
   IdentifierPatternNode,
+  IfNode,
   MemberNode,
   SyntaxType,
 } from 'tree-sitter-tony'
@@ -34,6 +35,7 @@ import {
   generateEliseIf,
   generateGenerator,
   generateIdentifierPattern,
+  generateIf,
   generateMember,
 } from './generators'
 import {
@@ -168,7 +170,7 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
         typedNode as TypedNode<IdentifierPatternNode>,
       )
     case SyntaxType.If:
-      throw new NotImplementedError('Tony cannot generate code for ifs yet.')
+      return handleIf(state, typedNode as TypedNode<IfNode>)
     // imports are generated in handleProgram
     case SyntaxType.Import:
       return ''
@@ -397,6 +399,16 @@ const handleIdentifierPattern = (
     'Identifier pattern nodes should always have an associated binding.',
   )
   return generateIdentifierPattern(name)
+}
+
+const handleIf = (state: State, typedNode: TypedNode<IfNode>): string => {
+  const condition = traverse(state, typedNode.conditionNode)
+  const body = traverse(state, typedNode.bodyNode)
+  const alternativeBodies = typedNode.elseIfNodes.map((elseIf) =>
+    traverse(state, elseIf),
+  )
+  const alternativeBody = safeApply(traverse)(state, typedNode.elseNode)
+  return generateIf(condition, body, alternativeBodies, alternativeBody)
 }
 
 const handleMember = (

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -14,6 +14,7 @@ import {
   IdentifierPatternNode,
   IfNode,
   InfixApplicationNode,
+  InterpolationNode,
   MemberNode,
   SyntaxType,
 } from 'tree-sitter-tony'
@@ -194,8 +195,9 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
         'Tony cannot generate code for interfaces yet.',
       )
     case SyntaxType.Interpolation:
-      throw new NotImplementedError(
-        'Tony cannot generate code for interpolations yet.',
+      return traverse(
+        state,
+        (typedNode as TypedNode<InterpolationNode>).termNode,
       )
     case SyntaxType.LeftSection:
       throw new NotImplementedError(

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -1,15 +1,233 @@
+import { AbstractionNode, SyntaxType } from 'tree-sitter-tony'
+import { Emit, buildFileEmit } from '../types/emit'
 import { GlobalScope, TypedFileScope } from '../types/analyze/scopes'
 import { LogLevel, log } from '../logger'
+import { NotImplementedError, assert } from '../types/errors/internal'
 import { Config } from '../config'
-import { Emit } from '../types/emit'
+import { TermNode } from '../types/nodes'
+import { TypedNode } from '../types/type_inference/nodes'
 
 export const generateCode = (
   config: Config,
   globalScope: GlobalScope<TypedFileScope>,
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
 ): Emit => {
   log(config, LogLevel.Info, 'Generating code')
 
-  console.log(globalScope)
+  return globalScope.scopes.map(generateCodeForFile)
+}
+
+const generateCodeForFile = (fileScope: TypedFileScope) =>
+  buildFileEmit(fileScope.file, traverse(fileScope.typedNode))
+
+const traverse = (typedNode: TypedNode<TermNode>): string => {
+  assert(
+    typedNode.node.type !== SyntaxType.ERROR,
+    'Code generation should not be run on scopes that include errors.',
+  )
+
+  switch (typedNode.node.type) {
+    case SyntaxType.Abstraction:
+      return handleAbstraction(typedNode as TypedNode<AbstractionNode>)
+    case SyntaxType.AbstractionBranch:
+      throw new NotImplementedError(
+        'Tony cannot generate code for abstraction branches yet.',
+      )
+    case SyntaxType.Access:
+      throw new NotImplementedError(
+        'Tony cannot generate code for access operations yet.',
+      )
+    case SyntaxType.Application:
+      throw new NotImplementedError(
+        'Tony cannot generate code for applications yet.',
+      )
+    case SyntaxType.Argument:
+      throw new NotImplementedError(
+        'Tony cannot generate code for arguments yet.',
+      )
+    case SyntaxType.Assignment:
+      throw new NotImplementedError(
+        'Tony cannot generate code for assignments yet.',
+      )
+    case SyntaxType.Block:
+      throw new NotImplementedError('Tony cannot generate code for blocks yet.')
+    case SyntaxType.Boolean:
+      return typedNode.node.text
+    case SyntaxType.Case:
+      throw new NotImplementedError('Tony cannot generate code for cases yet.')
+    case SyntaxType.DestructuringPattern:
+      throw new NotImplementedError(
+        'Tony cannot generate code for destructuring patterns yet.',
+      )
+    case SyntaxType.ElseIf:
+      throw new NotImplementedError(
+        'Tony cannot generate code for else ifs yet.',
+      )
+    case SyntaxType.Enum:
+      throw new NotImplementedError('Tony cannot generate code for enums yet.')
+    case SyntaxType.EnumValue:
+      throw new NotImplementedError(
+        'Tony cannot generate code for enum values yet.',
+      )
+    case SyntaxType.Export:
+      throw new NotImplementedError(
+        'Tony cannot generate code for exports yet.',
+      )
+    case SyntaxType.ExportedImport:
+      throw new NotImplementedError(
+        'Tony cannot generate code for exported imports yet.',
+      )
+    case SyntaxType.Generator:
+      throw new NotImplementedError(
+        'Tony cannot generate code for generators yet.',
+      )
+    case SyntaxType.Group:
+      throw new NotImplementedError('Tony cannot generate code for groups yet.')
+    case SyntaxType.Identifier:
+      throw new NotImplementedError(
+        'Tony cannot generate code for identifiers yet.',
+      )
+    case SyntaxType.IdentifierPattern:
+      throw new NotImplementedError(
+        'Tony cannot generate code for identifier patterns yet.',
+      )
+    case SyntaxType.If:
+      throw new NotImplementedError('Tony cannot generate code for ifs yet.')
+    case SyntaxType.Import:
+      throw new NotImplementedError(
+        'Tony cannot generate code for imports yet.',
+      )
+    case SyntaxType.ImportIdentifier:
+      throw new NotImplementedError(
+        'Tony cannot generate code for identifier imports yet.',
+      )
+    case SyntaxType.ImportType:
+      throw new NotImplementedError(
+        'Tony cannot generate code for type imports yet.',
+      )
+    case SyntaxType.InfixApplication:
+      throw new NotImplementedError(
+        'Tony cannot generate code for infix applications yet.',
+      )
+    case SyntaxType.Interface:
+      throw new NotImplementedError(
+        'Tony cannot generate code for interfaces yet.',
+      )
+    case SyntaxType.Interpolation:
+      throw new NotImplementedError(
+        'Tony cannot generate code for interpolations yet.',
+      )
+    case SyntaxType.LeftSection:
+      throw new NotImplementedError(
+        'Tony cannot generate code for left sections yet.',
+      )
+    case SyntaxType.List:
+      throw new NotImplementedError('Tony cannot generate code for lists yet.')
+    case SyntaxType.ListComprehension:
+      throw new NotImplementedError(
+        'Tony cannot generate code for list comprehensions yet.',
+      )
+    case SyntaxType.ListPattern:
+      throw new NotImplementedError(
+        'Tony cannot generate code for list patterns yet.',
+      )
+    case SyntaxType.Member:
+      throw new NotImplementedError(
+        'Tony cannot generate code for members yet.',
+      )
+    case SyntaxType.MemberPattern:
+      throw new NotImplementedError(
+        'Tony cannot generate code for member patterns yet.',
+      )
+    case SyntaxType.Number:
+      return typedNode.node.text
+    case SyntaxType.PatternGroup:
+      throw new NotImplementedError(
+        'Tony cannot generate code for pattern groups yet.',
+      )
+    case SyntaxType.Pipeline:
+      throw new NotImplementedError(
+        'Tony cannot generate code for pipelines yet.',
+      )
+    case SyntaxType.PrefixApplication:
+      throw new NotImplementedError(
+        'Tony cannot generate code for prefix applications yet.',
+      )
+    case SyntaxType.Program:
+      throw new NotImplementedError(
+        'Tony cannot generate code for programs yet.',
+      )
+    case SyntaxType.RawString:
+      throw new NotImplementedError(
+        'Tony cannot generate code for raw strings yet.',
+      )
+    case SyntaxType.Regex:
+      return typedNode.node.text
+    case SyntaxType.Rest:
+      throw new NotImplementedError(
+        'Tony cannot generate code for rest parameters yet.',
+      )
+    case SyntaxType.Return:
+      throw new NotImplementedError(
+        'Tony cannot generate code for returns yet.',
+      )
+    case SyntaxType.RightSection:
+      throw new NotImplementedError(
+        'Tony cannot generate code for right sections yet.',
+      )
+    case SyntaxType.ShorthandMemberPattern:
+      throw new NotImplementedError(
+        'Tony cannot generate code for shorthand member patterns yet.',
+      )
+    case SyntaxType.Spread:
+      throw new NotImplementedError(
+        'Tony cannot generate code for spreads yet.',
+      )
+    case SyntaxType.String:
+      throw new NotImplementedError(
+        'Tony cannot generate code for strings yet.',
+      )
+    case SyntaxType.Struct:
+      throw new NotImplementedError(
+        'Tony cannot generate code for structs yet.',
+      )
+    case SyntaxType.StructPattern:
+      throw new NotImplementedError(
+        'Tony cannot generate code for struct patterns yet.',
+      )
+    case SyntaxType.TaggedPattern:
+      throw new NotImplementedError(
+        'Tony cannot generate code for tagged patterns yet.',
+      )
+    case SyntaxType.TaggedValue:
+      throw new NotImplementedError(
+        'Tony cannot generate code for tagged values yet.',
+      )
+    case SyntaxType.Tuple:
+      throw new NotImplementedError('Tony cannot generate code for tuples yet.')
+    case SyntaxType.TuplePattern:
+      throw new NotImplementedError(
+        'Tony cannot generate code for tuple patterns yet.',
+      )
+    case SyntaxType.TypeAlias:
+      throw new NotImplementedError(
+        'Tony cannot generate code for type aliases yet.',
+      )
+    case SyntaxType.TypeHint:
+      throw new NotImplementedError(
+        'Tony cannot generate code for type hints yet.',
+      )
+    case SyntaxType.When:
+      throw new NotImplementedError('Tony cannot generate code for whens yet.')
+  }
+}
+
+const handleAbstraction = (typedNode: TypedNode<AbstractionNode>): string => {
+  const branches = typedNode.branchNodes
+    .map((branch) => traverse(branch))
+    .join(',')
+
+  return (
+    'stdlib.Curry.perform((...args)=>' +
+    `stdlib.ResolveAbstractionBranch.perform(args,[${branches}]))`
+  )
 }

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -24,6 +24,7 @@ import {
   ShorthandAccessIdentifierNode,
   StructNode,
   SyntaxType,
+  TypeHintNode,
 } from 'tree-sitter-tony'
 import { Emit, buildFileEmit } from '../types/emit'
 import {
@@ -271,13 +272,9 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
     case SyntaxType.Tuple:
       throw new NotImplementedError('Tony cannot generate code for tuples yet.')
     case SyntaxType.TypeAlias:
-      throw new NotImplementedError(
-        'Tony cannot generate code for type aliases yet.',
-      )
+      return ''
     case SyntaxType.TypeHint:
-      throw new NotImplementedError(
-        'Tony cannot generate code for type hints yet.',
-      )
+      return traverse(state, (typedNode as TypedNode<TypeHintNode>).valueNode)
     case SyntaxType.When:
       throw new NotImplementedError('Tony cannot generate code for whens yet.')
   }

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -17,6 +17,7 @@ import {
   ListComprehensionNode,
   ListNode,
   MemberNode,
+  PipelineNode,
   StructNode,
   SyntaxType,
 } from 'tree-sitter-tony'
@@ -47,6 +48,7 @@ import {
   generateList,
   generateListComprehension,
   generateMember,
+  generatePipeline,
   generateStruct,
 } from './generators'
 import {
@@ -211,9 +213,7 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
     case SyntaxType.Number:
       return typedNode.node.text
     case SyntaxType.Pipeline:
-      throw new NotImplementedError(
-        'Tony cannot generate code for pipelines yet.',
-      )
+      return handlePipeline(state, typedNode as TypedNode<PipelineNode>)
     case SyntaxType.PrefixApplication:
       throw new NotImplementedError(
         'Tony cannot generate code for prefix applications yet.',
@@ -243,6 +243,10 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
     case SyntaxType.ShorthandMemberIdentifier:
       throw new NotImplementedError(
         'Tony cannot generate code for shorthand member identifiers yet.',
+      )
+    case SyntaxType.ShorthandMember:
+      throw new NotImplementedError(
+        'Tony cannot generate code for shorthand members yet.',
       )
     case SyntaxType.Spread:
       throw new NotImplementedError(
@@ -419,6 +423,15 @@ const handleMember = (
   const key = traverse(state, typedNode.keyNode)
   const value = traverse(state, typedNode.valueNode)
   return generateMember(key, value)
+}
+
+const handlePipeline = (
+  state: State,
+  typedNode: TypedNode<PipelineNode>,
+): string => {
+  const name = traverse(state, typedNode.nameNode)
+  const value = traverse(state, typedNode.valueNode)
+  return generatePipeline(name, value)
 }
 
 const handleStruct = (

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -17,6 +17,7 @@ import {
   ListComprehensionNode,
   ListNode,
   MemberNode,
+  StructNode,
   SyntaxType,
 } from 'tree-sitter-tony'
 import { Emit, buildFileEmit } from '../types/emit'
@@ -46,6 +47,7 @@ import {
   generateList,
   generateListComprehension,
   generateMember,
+  generateStruct,
 } from './generators'
 import {
   generateBindingName,
@@ -251,9 +253,7 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
         'Tony cannot generate code for strings yet.',
       )
     case SyntaxType.Struct:
-      throw new NotImplementedError(
-        'Tony cannot generate code for structs yet.',
-      )
+      return handleStruct(state, typedNode as TypedNode<StructNode>)
     case SyntaxType.TaggedValue:
       throw new NotImplementedError(
         'Tony cannot generate code for tagged values yet.',
@@ -419,4 +419,12 @@ const handleMember = (
   const key = traverse(state, typedNode.keyNode)
   const value = traverse(state, typedNode.valueNode)
   return generateMember(key, value)
+}
+
+const handleStruct = (
+  state: State,
+  typedNode: TypedNode<StructNode>,
+): string => {
+  const members = typedNode.memberNodes.map((member) => traverse(state, member))
+  return generateStruct(members)
 }

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -6,6 +6,7 @@ import {
   BlockNode,
   CaseNode,
   ElseIfNode,
+  ExportNode,
   SyntaxType,
 } from 'tree-sitter-tony'
 import { Emit, buildFileEmit } from '../types/emit'
@@ -133,9 +134,7 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
         'Tony cannot generate code for enum values yet.',
       )
     case SyntaxType.Export:
-      throw new NotImplementedError(
-        'Tony cannot generate code for exports yet.',
-      )
+      return handleExport(state, typedNode as TypedNode<ExportNode>)
     case SyntaxType.ExportedImport:
       throw new NotImplementedError(
         'Tony cannot generate code for exported imports yet.',
@@ -351,3 +350,6 @@ const handleElseIf = (
   const body = traverse(state, typedNode.bodyNode)
   return generateEliseIf(condition, body)
 }
+
+const handleExport = (state: State, typedNode: TypedNode<ExportNode>): string =>
+  traverse(state, typedNode.declarationNode)

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -18,6 +18,7 @@ import {
   ListNode,
   MemberNode,
   PipelineNode,
+  PrefixApplicationNode,
   StructNode,
   SyntaxType,
 } from 'tree-sitter-tony'
@@ -44,11 +45,9 @@ import {
   generateEliseIf,
   generateGenerator,
   generateIf,
-  generateInfixApplication,
   generateList,
   generateListComprehension,
   generateMember,
-  generatePipeline,
   generateStruct,
 } from './generators'
 import {
@@ -215,8 +214,9 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
     case SyntaxType.Pipeline:
       return handlePipeline(state, typedNode as TypedNode<PipelineNode>)
     case SyntaxType.PrefixApplication:
-      throw new NotImplementedError(
-        'Tony cannot generate code for prefix applications yet.',
+      return handlePrefixApplication(
+        state,
+        typedNode as TypedNode<PrefixApplicationNode>,
       )
     case SyntaxType.Program:
       throw new NotImplementedError(
@@ -395,7 +395,7 @@ const handleInfixApplication = (
   const value = traverse(state, typedNode.nameNode)
   const left = traverse(state, typedNode.leftNode)
   const right = traverse(state, typedNode.rightNode)
-  return generateInfixApplication(value, left, right)
+  return generateApplication(value, [left, right])
 }
 
 const handleList = (state: State, typedNode: TypedNode<ListNode>): string => {
@@ -431,7 +431,16 @@ const handlePipeline = (
 ): string => {
   const name = traverse(state, typedNode.nameNode)
   const value = traverse(state, typedNode.valueNode)
-  return generatePipeline(name, value)
+  return generateApplication(name, [value])
+}
+
+const handlePrefixApplication = (
+  state: State,
+  typedNode: TypedNode<PrefixApplicationNode>,
+): string => {
+  const name = traverse(state, typedNode.nameNode)
+  const value = traverse(state, typedNode.valueNode)
+  return generateApplication(name, [value])
 }
 
 const handleStruct = (

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -9,6 +9,7 @@ import {
   ExportNode,
   GeneratorNode,
   IdentifierNode,
+  IdentifierPatternNode,
   MemberNode,
   SyntaxType,
 } from 'tree-sitter-tony'
@@ -32,6 +33,7 @@ import {
   generateCase,
   generateEliseIf,
   generateGenerator,
+  generateIdentifierPattern,
   generateMember,
 } from './generators'
 import {
@@ -161,8 +163,9 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
         (typedNode as TypedNode<IdentifierNode>).binding,
       )
     case SyntaxType.IdentifierPattern:
-      throw new NotImplementedError(
-        'Tony cannot generate code for identifier patterns yet.',
+      return handleIdentifierPattern(
+        state,
+        typedNode as TypedNode<IdentifierPatternNode>,
       )
     case SyntaxType.If:
       throw new NotImplementedError('Tony cannot generate code for ifs yet.')
@@ -379,6 +382,21 @@ const handleGenerator = (
     'Generator nodes should always have an associated binding.',
   )
   return generateGenerator(name, value, condition)
+}
+
+const handleIdentifierPattern = (
+  state: State,
+  typedNode: TypedNode<IdentifierPatternNode>,
+): string => {
+  const name = generateDeclaredBindingName(
+    state.scopes[0].terms,
+    typedNode.node,
+  )
+  assert(
+    name !== undefined,
+    'Identifier pattern nodes should always have an associated binding.',
+  )
+  return generateIdentifierPattern(name)
 }
 
 const handleMember = (

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -2,6 +2,7 @@ import {
   AbstractionBranchNode,
   AbstractionNode,
   AccessNode,
+  ApplicationNode,
   AssignmentNode,
   BlockNode,
   CaseNode,
@@ -29,6 +30,7 @@ import {
   generateAbstraction,
   generateAbstractionBranch,
   generateAccess,
+  generateApplication,
   generateAssignment,
   generateBlock,
   generateCase,
@@ -120,9 +122,7 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
     case SyntaxType.Access:
       return handleAccess(state, typedNode as TypedNode<AccessNode>)
     case SyntaxType.Application:
-      throw new NotImplementedError(
-        'Tony cannot generate code for applications yet.',
-      )
+      return handleApplication(state, typedNode as TypedNode<ApplicationNode>)
     case SyntaxType.Argument:
       throw new NotImplementedError(
         'Tony cannot generate code for arguments yet.',
@@ -334,6 +334,17 @@ const handleAccess = (
   const name = traverse(state, typedNode.nameNode)
   const value = traverse(state, typedNode.valueNode)
   return generateAccess(name, value)
+}
+
+const handleApplication = (
+  state: State,
+  typedNode: TypedNode<ApplicationNode>,
+): string => {
+  const value = traverse(state, typedNode.nameNode)
+  const args = typedNode.elementNodes.map((argument) =>
+    traverse(state, argument),
+  )
+  return generateApplication(value, args)
 }
 
 const handleAssignment = (

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -7,6 +7,7 @@ import {
   CaseNode,
   ElseIfNode,
   ExportNode,
+  MemberNode,
   SyntaxType,
 } from 'tree-sitter-tony'
 import { Emit, buildFileEmit } from '../types/emit'
@@ -28,6 +29,7 @@ import {
   generateBlock,
   generateCase,
   generateEliseIf,
+  generateMember,
 } from './generators'
 import { safeApply, traverseScopes } from '../util/traverse'
 import { Config } from '../config'
@@ -194,9 +196,7 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
         'Tony cannot generate code for list patterns yet.',
       )
     case SyntaxType.Member:
-      throw new NotImplementedError(
-        'Tony cannot generate code for members yet.',
-      )
+      return handleMember(state, typedNode as TypedNode<MemberNode>)
     case SyntaxType.MemberPattern:
       throw new NotImplementedError(
         'Tony cannot generate code for member patterns yet.',
@@ -240,6 +240,10 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
     case SyntaxType.ShorthandAccessIdentifier:
       throw new NotImplementedError(
         'Tony cannot generate code for shorthand access identifiers yet.',
+      )
+    case SyntaxType.ShorthandMemberIdentifier:
+      throw new NotImplementedError(
+        'Tony cannot generate code for shorthand member identifiers yet.',
       )
     case SyntaxType.ShorthandMemberPattern:
       throw new NotImplementedError(
@@ -353,3 +357,12 @@ const handleElseIf = (
 
 const handleExport = (state: State, typedNode: TypedNode<ExportNode>): string =>
   traverse(state, typedNode.declarationNode)
+
+const handleMember = (
+  state: State,
+  typedNode: TypedNode<MemberNode>,
+): string => {
+  const key = traverse(state, typedNode.keyNode)
+  const value = traverse(state, typedNode.valueNode)
+  return generateMember(key, value)
+}

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -7,6 +7,7 @@ import { Config } from '../config'
 import { TermNode } from '../types/nodes'
 import { TypedNode } from '../types/type_inference/nodes'
 import { generateAbstraction } from './util'
+import { traverseScopes } from '../util/traverse'
 
 export const generateCode = (
   config: Config,
@@ -20,7 +21,15 @@ export const generateCode = (
 const generateCodeForFile = (fileScope: TypedFileScope) =>
   buildFileEmit(fileScope.file, traverse(fileScope.typedNode))
 
-const traverse = (typedNode: TypedNode<TermNode>): string => {
+const traverse = (typedNode: TypedNode<TermNode>): string =>
+  traverseScopes(
+    typedNode.node,
+    () => handleNode(typedNode),
+    // TODO: enter nested scope here
+    () => handleNode(typedNode),
+  )
+
+const handleNode = (typedNode: TypedNode<TermNode>): string => {
   assert(
     typedNode.node.type !== SyntaxType.ERROR,
     'Code generation should not be run on scopes that include errors.',

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -25,6 +25,7 @@ import {
   StructNode,
   SyntaxType,
   TypeHintNode,
+  WhenNode,
 } from 'tree-sitter-tony'
 import { Emit, buildFileEmit } from '../types/emit'
 import {
@@ -57,6 +58,7 @@ import {
   generateReturn,
   generateShorthandAccessIdentifier,
   generateStruct,
+  generateWhen,
 } from './generators'
 import {
   generateBindingName,
@@ -276,7 +278,7 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
     case SyntaxType.TypeHint:
       return traverse(state, (typedNode as TypedNode<TypeHintNode>).valueNode)
     case SyntaxType.When:
-      throw new NotImplementedError('Tony cannot generate code for whens yet.')
+      return handleWhen(state, typedNode as TypedNode<WhenNode>)
   }
 }
 
@@ -488,4 +490,13 @@ const handleStruct = (
 ): string => {
   const members = typedNode.memberNodes.map((member) => traverse(state, member))
   return generateStruct(members)
+}
+
+const handleWhen = (state: State, typedNode: TypedNode<WhenNode>): string => {
+  // we may need to change the scope here
+  const patterns = typedNode.patternNodes.map((patternNode) =>
+    generatePattern(state.scopes[0], patternNode),
+  )
+  const body = traverse(state, typedNode.bodyNode)
+  return generateWhen(patterns, body)
 }

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -15,6 +15,7 @@ import {
   IfNode,
   InfixApplicationNode,
   InterpolationNode,
+  ListComprehensionNode,
   ListNode,
   MemberNode,
   SyntaxType,
@@ -45,6 +46,7 @@ import {
   generateIf,
   generateInfixApplication,
   generateList,
+  generateListComprehension,
   generateMember,
 } from './generators'
 import {
@@ -208,8 +210,9 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
     case SyntaxType.List:
       return handleList(state, typedNode as TypedNode<ListNode>)
     case SyntaxType.ListComprehension:
-      throw new NotImplementedError(
-        'Tony cannot generate code for list comprehensions yet.',
+      return handleListComprehension(
+        state,
+        typedNode as TypedNode<ListComprehensionNode>,
       )
     case SyntaxType.ListPattern:
       throw new NotImplementedError(
@@ -452,6 +455,17 @@ const handleList = (state: State, typedNode: TypedNode<ListNode>): string => {
     traverse(state, element),
   )
   return generateList(elements)
+}
+
+const handleListComprehension = (
+  state: State,
+  typedNode: TypedNode<ListComprehensionNode>,
+): string => {
+  const generators = typedNode.generatorNodes.map((generator) =>
+    traverse(state, generator),
+  )
+  const body = traverse(state, typedNode.bodyNode)
+  return generateListComprehension(generators, body)
 }
 
 const handleMember = (

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -21,6 +21,7 @@ import {
   PrefixApplicationNode,
   ProgramNode,
   ReturnNode,
+  ShorthandAccessIdentifierNode,
   StructNode,
   SyntaxType,
 } from 'tree-sitter-tony'
@@ -53,6 +54,7 @@ import {
   generateMember,
   generateProgram,
   generateReturn,
+  generateShorthandAccessIdentifier,
   generateStruct,
 } from './generators'
 import {
@@ -66,11 +68,8 @@ import { generatePattern, generatePatterns } from './patterns'
 import { Config } from '../config'
 import { TermNode } from '../types/nodes'
 import { TypedNode } from '../types/type_inference/nodes'
+import { isImportedBinding } from '../types/analyze/bindings'
 import { traverseScopes } from '../util/traverse'
-import {
-  ImportedTermBinding,
-  isImportedBinding,
-} from '../types/analyze/bindings'
 
 type State = {
   /**
@@ -244,8 +243,8 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
         'Tony cannot generate code for right sections yet.',
       )
     case SyntaxType.ShorthandAccessIdentifier:
-      throw new NotImplementedError(
-        'Tony cannot generate code for shorthand access identifiers yet.',
+      return handleShorthandAccessIdentifier(
+        typedNode as TypedNode<ShorthandAccessIdentifierNode>,
       )
     case SyntaxType.ShorthandMemberIdentifier:
       throw new NotImplementedError(
@@ -475,6 +474,15 @@ const handleReturn = (
 ): string => {
   const value = traverse(state, typedNode.valueNode)
   return generateReturn(value)
+}
+
+const handleShorthandAccessIdentifier = (
+  typedNode: TypedNode<ShorthandAccessIdentifierNode>,
+): string => {
+  const name = generateBindingName(
+    (typedNode as TypedNode<ShorthandAccessIdentifierNode>).binding,
+  )
+  return generateShorthandAccessIdentifier(name)
 }
 
 const handleStruct = (

--- a/src/code_generation/index.ts
+++ b/src/code_generation/index.ts
@@ -13,6 +13,7 @@ import {
   IdentifierNode,
   IdentifierPatternNode,
   IfNode,
+  InfixApplicationNode,
   MemberNode,
   SyntaxType,
 } from 'tree-sitter-tony'
@@ -40,6 +41,7 @@ import {
   generateGenerator,
   generateIdentifierPattern,
   generateIf,
+  generateInfixApplication,
   generateMember,
 } from './generators'
 import {
@@ -183,8 +185,9 @@ const handleNode = (state: State, typedNode: TypedNode<TermNode>): string => {
         'Tony cannot generate code for type imports yet.',
       )
     case SyntaxType.InfixApplication:
-      throw new NotImplementedError(
-        'Tony cannot generate code for infix applications yet.',
+      return handleInfixApplication(
+        state,
+        typedNode as TypedNode<InfixApplicationNode>,
       )
     case SyntaxType.Interface:
       throw new NotImplementedError(
@@ -428,6 +431,16 @@ const handleIf = (state: State, typedNode: TypedNode<IfNode>): string => {
   )
   const alternativeBody = safeApply(traverse)(state, typedNode.elseNode)
   return generateIf(condition, body, alternativeBodies, alternativeBody)
+}
+
+const handleInfixApplication = (
+  state: State,
+  typedNode: TypedNode<InfixApplicationNode>,
+): string => {
+  const value = traverse(state, typedNode.nameNode)
+  const left = traverse(state, typedNode.leftNode)
+  const right = traverse(state, typedNode.rightNode)
+  return generateInfixApplication(value, left, right)
 }
 
 const handleMember = (

--- a/src/code_generation/lib.ts
+++ b/src/code_generation/lib.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 
-const UTILS_MODULE = 'codeGeneration'
-const UTILS_PATH = path.join(__dirname, 'utils')
+const UTILS_MODULE = '$CODE_GENERATION'
+const UTILS_PATH = path.join(__dirname, '..', 'utils')
 const CURRY_FUNCTION = `${UTILS_MODULE}.curry`
 const PATTERN_MATCH_FUNCTION = `${UTILS_MODULE}.patternMatch`
 const RESOLVE_ABSTRACTION_BRANCH_FUNCTION = `${UTILS_MODULE}.resolveAbstractionBranch`

--- a/src/code_generation/lib/index.ts
+++ b/src/code_generation/lib/index.ts
@@ -3,12 +3,13 @@ const CURRY_FUNCTION = `${UTILS_MODULE}.curry`
 const RESOLVE_ABSTRACTION_BRANCH_FUNCTION = `${UTILS_MODULE}.resolveAbstractionBranch`
 const ARGUMENTS_NAME = 'args'
 
-const resolveAbstractionBranch = (branches: string[]) => {
+export const resolveAbstractionBranch = (branches: string[]): string => {
   const joinedBranches = branches.join(',')
   return `${RESOLVE_ABSTRACTION_BRANCH_FUNCTION}(${ARGUMENTS_NAME},[${joinedBranches}])`
 }
 
-const curry = (fn: string) => `${CURRY_FUNCTION}((...${ARGUMENTS_NAME})=>${fn})`
+export const curry = (fn: string): string =>
+  `${CURRY_FUNCTION}((...${ARGUMENTS_NAME})=>${fn})`
 
-export const generateAbstraction = (branches: string[]): string =>
-  curry(resolveAbstractionBranch(branches))
+export const patternMatch = (parameters: string[], body: string): string =>
+  `(match)=>{const [${parameters.join(',')}]=match;return ${body}}`

--- a/src/code_generation/lib/index.ts
+++ b/src/code_generation/lib/index.ts
@@ -1,15 +1,21 @@
 const UTILS_MODULE = 'codeGeneration'
 const CURRY_FUNCTION = `${UTILS_MODULE}.curry`
+const PATTERN_MATCH_FUNCTION = `${UTILS_MODULE}.patternMatch`
 const RESOLVE_ABSTRACTION_BRANCH_FUNCTION = `${UTILS_MODULE}.resolveAbstractionBranch`
-const ARGUMENTS_NAME = 'args'
 
-export const resolveAbstractionBranch = (branches: string[]): string => {
+export const resolveAbstractionBranch = (
+  value: string,
+  branches: string[],
+  elseBranch?: string,
+): string => {
   const joinedBranches = branches.join(',')
-  return `${RESOLVE_ABSTRACTION_BRANCH_FUNCTION}(${ARGUMENTS_NAME},[${joinedBranches}])`
+  return `${RESOLVE_ABSTRACTION_BRANCH_FUNCTION}(${value},[${joinedBranches}],${
+    elseBranch ? `()=>${elseBranch}` : ''
+  })`
 }
 
-export const curry = (fn: string): string =>
-  `${CURRY_FUNCTION}((...${ARGUMENTS_NAME})=>${fn})`
+export const curry = (argumentsName: string, fn: string): string =>
+  `${CURRY_FUNCTION}((...${argumentsName})=>${fn})`
 
 export const patternMatchForAbstraction = (
   parameters: string,
@@ -22,4 +28,4 @@ export const patternMatch = (
   defaults: string,
   value: string,
 ): string =>
-  `(()=>{const value=${value};${identifiers}=new stdlib.PatternMatch({defaults:${defaults},overmatching:true}).perform(${pattern},value);return value})()`
+  `(()=>{const value=${value};${identifiers}=${PATTERN_MATCH_FUNCTION}({defaults:${defaults},overmatching:true},${pattern},value);return value})()`

--- a/src/code_generation/lib/index.ts
+++ b/src/code_generation/lib/index.ts
@@ -1,7 +1,12 @@
+import path from 'path'
+
 const UTILS_MODULE = 'codeGeneration'
+const UTILS_PATH = path.join(__dirname, 'utils')
 const CURRY_FUNCTION = `${UTILS_MODULE}.curry`
 const PATTERN_MATCH_FUNCTION = `${UTILS_MODULE}.patternMatch`
 const RESOLVE_ABSTRACTION_BRANCH_FUNCTION = `${UTILS_MODULE}.resolveAbstractionBranch`
+
+export const UTILS_IMPORT = `import * as ${UTILS_MODULE} from ${UTILS_PATH}`
 
 export const resolveAbstractionBranch = (
   value: string,

--- a/src/code_generation/lib/index.ts
+++ b/src/code_generation/lib/index.ts
@@ -11,5 +11,15 @@ export const resolveAbstractionBranch = (branches: string[]): string => {
 export const curry = (fn: string): string =>
   `${CURRY_FUNCTION}((...${ARGUMENTS_NAME})=>${fn})`
 
-export const patternMatch = (parameters: string[], body: string): string =>
-  `(match)=>{const [${parameters.join(',')}]=match;return ${body}}`
+export const patternMatchForAbstraction = (
+  parameters: string,
+  value: string,
+): string => `(match)=>{const ${parameters}=match;return ${value}}`
+
+export const patternMatch = (
+  pattern: string,
+  identifiers: string,
+  defaults: string,
+  value: string,
+): string =>
+  `(()=>{const value=${value};${identifiers}=new stdlib.PatternMatch({defaults:${defaults},overmatching:true}).perform(${pattern},value);return value})()`

--- a/src/code_generation/patterns.ts
+++ b/src/code_generation/patterns.ts
@@ -8,6 +8,7 @@ import {
   ShorthandMemberPatternNode,
   StructPatternNode,
   SyntaxType,
+  TuplePatternNode,
 } from 'tree-sitter-tony'
 import { LiteralNode, PatternNode, TermNode } from '../types/nodes'
 import { NotImplementedError, assert } from '../types/errors/internal'
@@ -158,6 +159,12 @@ export const traverse = (
         typedNode as TypedNode<StructPatternNode>,
         generateCode,
       )
+    case SyntaxType.TuplePattern:
+      return handleTuplePattern(
+        state,
+        typedNode as TypedNode<TuplePatternNode>,
+        generateCode,
+      )
 
     case SyntaxType.Boolean:
     case SyntaxType.Number:
@@ -293,5 +300,27 @@ const handleStructPattern = (
     generateStructPattern(memberPatterns, restPattern),
     [...memberIdentifiers, ...restIdentifiers],
     [...memberDefaults, ...restDefaults],
+  ]
+}
+
+const handleTuplePattern = (
+  state: State,
+  typedNode: TypedNode<TuplePatternNode>,
+  generateCode: GenerateCode,
+): Return => {
+  const [elementPatterns, elementIdentifiers, elementDefaults] = traverseAll(
+    state,
+    typedNode.elementNodes,
+    generateCode,
+  )
+  const [restPattern, restIdentifiers, restDefaults] = safeTraverse(
+    state,
+    typedNode.restNode,
+    generateCode,
+  )
+  return [
+    generateListPattern(elementPatterns, restPattern),
+    [...elementIdentifiers, ...restIdentifiers],
+    [...elementDefaults, ...restDefaults],
   ]
 }

--- a/src/code_generation/patterns.ts
+++ b/src/code_generation/patterns.ts
@@ -4,6 +4,7 @@ import {
   ListPatternNode,
   MemberPatternNode,
   PatternGroupNode,
+  RestNode,
   SyntaxType,
 } from 'tree-sitter-tony'
 import { LiteralNode, PatternNode, TermNode } from '../types/nodes'
@@ -126,6 +127,12 @@ export const traverse = (
       return traverse(
         state,
         (typedNode as TypedNode<PatternGroupNode>).patternNode,
+        generateCode,
+      )
+    case SyntaxType.Rest:
+      return traverse(
+        state,
+        (typedNode as TypedNode<RestNode>).nameNode,
         generateCode,
       )
 

--- a/src/code_generation/patterns.ts
+++ b/src/code_generation/patterns.ts
@@ -3,6 +3,7 @@ import {
   IdentifierPatternNode,
   ListPatternNode,
   MemberPatternNode,
+  PatternGroupNode,
   SyntaxType,
 } from 'tree-sitter-tony'
 import { LiteralNode, PatternNode, TermNode } from '../types/nodes'
@@ -121,6 +122,13 @@ export const traverse = (
         typedNode as TypedNode<MemberPatternNode>,
         generateCode,
       )
+    case SyntaxType.PatternGroup:
+      return traverse(
+        state,
+        (typedNode as TypedNode<PatternGroupNode>).patternNode,
+        generateCode,
+      )
+
     case SyntaxType.Boolean:
     case SyntaxType.Number:
     case SyntaxType.RawString:

--- a/src/code_generation/patterns.ts
+++ b/src/code_generation/patterns.ts
@@ -1,3 +1,8 @@
+import {
+  FileScope,
+  NestedScope,
+  NestingTermNode,
+} from '../types/analyze/scopes'
 import { PatternNode } from '../types/nodes'
 import { TypedNode } from '../types/type_inference/nodes'
 
@@ -13,11 +18,13 @@ export type GeneratedPatterns = [
 ]
 
 export const resolvePatterns = (
+  scope: FileScope<NestingTermNode> | NestedScope<NestingTermNode>,
   typedNodes: TypedNode<PatternNode>[],
 ): GeneratedPatterns =>
   typedNodes.reduce<GeneratedPatterns>(
     ([patterns, identifiersPatterns, defaultsPatterns], typedNode) => {
       const [pattern, identifiersPattern, defaultsPattern] = resolvePattern(
+        scope,
         typedNode,
       )
       return [
@@ -30,6 +37,7 @@ export const resolvePatterns = (
   )
 
 export const resolvePattern = (
+  scope: FileScope<NestingTermNode> | NestedScope<NestingTermNode>,
   typedNode: TypedNode<PatternNode>,
 ): GeneratedPattern => {}
 

--- a/src/code_generation/patterns.ts
+++ b/src/code_generation/patterns.ts
@@ -17,13 +17,13 @@ export type GeneratedPatterns = [
   defaultsPatterns: string[],
 ]
 
-export const resolvePatterns = (
+export const generatePatterns = (
   scope: FileScope<NestingTermNode> | NestedScope<NestingTermNode>,
   typedNodes: TypedNode<PatternNode>[],
 ): GeneratedPatterns =>
   typedNodes.reduce<GeneratedPatterns>(
     ([patterns, identifiersPatterns, defaultsPatterns], typedNode) => {
-      const [pattern, identifiersPattern, defaultsPattern] = resolvePattern(
+      const [pattern, identifiersPattern, defaultsPattern] = generatePattern(
         scope,
         typedNode,
       )
@@ -36,7 +36,7 @@ export const resolvePatterns = (
     [[], [], []],
   )
 
-export const resolvePattern = (
+export const generatePattern = (
   scope: FileScope<NestingTermNode> | NestedScope<NestingTermNode>,
   typedNode: TypedNode<PatternNode>,
 ): GeneratedPattern => {}

--- a/src/code_generation/patterns.ts
+++ b/src/code_generation/patterns.ts
@@ -1,7 +1,49 @@
-export const resolvePattern = (
-  pattern: string,
-): [pattern: string, identifiersPattern: string, defaultsPattern: string] => {
-  const object = parsePattern(pattern)
-}
+import { PatternNode } from '../types/nodes'
+import { TypedNode } from '../types/type_inference/nodes'
 
-const parsePattern = (pattern: string): object => JSON.parse(pattern)
+export type GeneratedPattern = [
+  pattern: string,
+  identifiersPattern: string,
+  defaultsPattern: string,
+]
+export type GeneratedPatterns = [
+  patterns: string[],
+  identifiersPatterns: string[],
+  defaultsPatterns: string[],
+]
+
+export const resolvePatterns = (
+  typedNodes: TypedNode<PatternNode>[],
+): GeneratedPatterns =>
+  typedNodes.reduce<GeneratedPatterns>(
+    ([patterns, identifiersPatterns, defaultsPatterns], typedNode) => {
+      const [pattern, identifiersPattern, defaultsPattern] = resolvePattern(
+        typedNode,
+      )
+      return [
+        [...patterns, pattern],
+        [...identifiersPatterns, identifiersPattern],
+        [...defaultsPatterns, defaultsPattern],
+      ]
+    },
+    [[], [], []],
+  )
+
+export const resolvePattern = (
+  typedNode: TypedNode<PatternNode>,
+): GeneratedPattern => {}
+
+// const handleIdentifierPattern = (
+//   state: State,
+//   typedNode: TypedNode<IdentifierPatternNode>,
+// ): string => {
+//   const name = generateDeclaredBindingName(
+//     state.scopes[0].terms,
+//     typedNode.node,
+//   )
+//   assert(
+//     name !== undefined,
+//     'Identifier pattern nodes should always have an associated binding.',
+//   )
+//   return generateIdentifierPattern(name)
+// }

--- a/src/code_generation/patterns.ts
+++ b/src/code_generation/patterns.ts
@@ -1,4 +1,7 @@
 export const resolvePattern = (
-  parameters: string[],
-  restPattern?: string,
-): [pattern: string, identifiers: string[], defaults: string[]] => {}
+  pattern: string,
+): [pattern: string, identifiersPattern: string, defaultsPattern: string] => {
+  const object = parsePattern(pattern)
+}
+
+const parsePattern = (pattern: string): object => JSON.parse(pattern)

--- a/src/code_generation/patterns.ts
+++ b/src/code_generation/patterns.ts
@@ -159,6 +159,10 @@ export const traverse = (
         typedNode as TypedNode<StructPatternNode>,
         generateCode,
       )
+    case SyntaxType.TaggedPattern:
+      throw new NotImplementedError(
+        'Tony cannot generate code for tagged patterns yet.',
+      )
     case SyntaxType.TuplePattern:
       return handleTuplePattern(
         state,
@@ -189,7 +193,7 @@ const handleDestructuringPattern = (
   )
   if (name !== undefined)
     throw new NotImplementedError(
-      'Destructuring pattern bindings cannot yet be generated.',
+      'Tony cannot generate code for destructuring patterns with bindings yet.',
     )
   return traverse(state, typedNode.patternNode, generateCode)
 }

--- a/src/code_generation/patterns.ts
+++ b/src/code_generation/patterns.ts
@@ -1,0 +1,4 @@
+export const resolvePattern = (
+  parameters: string[],
+  restPattern?: string,
+): [pattern: string, identifiers: string[], defaults: string[]] => {}

--- a/src/code_generation/patterns.ts
+++ b/src/code_generation/patterns.ts
@@ -1,5 +1,5 @@
 import { IdentifierPatternNode, SyntaxType } from 'tree-sitter-tony'
-import { PatternNode, TermNode } from '../types/nodes'
+import { LiteralNode, PatternNode, TermNode } from '../types/nodes'
 import { generateIdentifierPattern, generateListPattern } from './generators'
 import { State } from './types'
 import { TypedNode } from '../types/type_inference/nodes'
@@ -11,7 +11,6 @@ export type GeneratedPattern = [
   identifiersPattern: string,
   defaultsPattern: string,
 ]
-
 export type GeneratedPatterns = [
   patterns: string[],
   identifiersPatterns: string[],
@@ -19,7 +18,6 @@ export type GeneratedPatterns = [
 ]
 
 type Return = [pattern: string, identifiers: string[], defaults: string[]]
-
 type GenerateCode = (state: State, typedNode: TypedNode<TermNode>) => string
 
 export const generatePatterns = (
@@ -72,6 +70,15 @@ export const traverse = (
         typedNode as TypedNode<IdentifierPatternNode>,
         generateCode,
       )
+    case SyntaxType.Boolean:
+    case SyntaxType.Number:
+    case SyntaxType.RawString:
+    case SyntaxType.Regex:
+      return handleLiteral(
+        state,
+        typedNode as TypedNode<LiteralNode>,
+        generateCode,
+      )
   }
 }
 
@@ -94,3 +101,9 @@ const handleIdentifierPattern = (
     [typedNode.defaultNode ? generateCode(state, typedNode.defaultNode) : ''],
   ]
 }
+
+const handleLiteral = (
+  state: State,
+  typedNode: TypedNode<LiteralNode>,
+  generateCode: GenerateCode,
+): Return => [generateCode(state, typedNode), [], []]

--- a/src/code_generation/strings.ts
+++ b/src/code_generation/strings.ts
@@ -1,0 +1,24 @@
+import { assert } from '../types/errors/internal'
+
+export const parseStringContent = (value: string, qt = '`'): string => {
+  const content = value.slice(1, -1)
+  // Removes one escape when there are an even number of escapes before a `qt`
+  // inside a string.
+  const regex = new RegExp(`(?<!\\\\)(\\\\\\\\)+(?!\\\\)(?=${qt})`, 'g')
+  return content
+    .replace(new RegExp(qt, 'g'), `\\${qt}`)
+    .replace(regex, (s) => s.substring(1))
+}
+
+export const injectInterpolations = (
+  content: string,
+  interpolations: string[],
+): string =>
+  content.replace(/(?<!\\){/g, '${').replace(/(?<=\${).+?(?=})/g, () => {
+    const value = interpolations.shift()
+    assert(
+      value !== undefined,
+      'The number of generated interpolations and interpolations in the string should match.',
+    )
+    return value
+  })

--- a/src/code_generation/types.ts
+++ b/src/code_generation/types.ts
@@ -1,0 +1,13 @@
+import {
+  FileScope,
+  NestedScope,
+  NestingTermNode,
+} from '../types/analyze/scopes'
+
+export type State = {
+  /**
+   * A stack of all scopes starting with the closest scope and ending with the
+   * symbol table.
+   */
+  scopes: (FileScope<NestingTermNode> | NestedScope<NestingTermNode>)[]
+}

--- a/src/code_generation/util.ts
+++ b/src/code_generation/util.ts
@@ -1,0 +1,15 @@
+const UTILS_MODULE = 'codeGeneration'
+const CURRY_FUNCTION = `${UTILS_MODULE}.curry`
+const RESOLVE_ABSTRACTION_BRANCH_FUNCTION = `${UTILS_MODULE}.resolveAbstractionBranch`
+const ARGUMENTS_NAME = 'args'
+
+const resolveAbstractionBranch = (branches: string[]) => {
+  const joinedBranches = branches.join(',')
+  return `${RESOLVE_ABSTRACTION_BRANCH_FUNCTION}(${ARGUMENTS_NAME},[${joinedBranches}])`
+}
+
+const curry = (fn: string) =>
+  `${CURRY_FUNCTION}((...${ARGUMENTS_NAME}) => ${fn})`
+
+export const generateAbstraction = (branches: string[]): string =>
+  curry(resolveAbstractionBranch(branches))

--- a/src/code_generation/util.ts
+++ b/src/code_generation/util.ts
@@ -9,7 +9,7 @@ const resolveAbstractionBranch = (branches: string[]) => {
 }
 
 const curry = (fn: string) =>
-  `${CURRY_FUNCTION}((...${ARGUMENTS_NAME}) => ${fn})`
+  `${CURRY_FUNCTION}((...${ARGUMENTS_NAME})=>${fn})`
 
 export const generateAbstraction = (branches: string[]): string =>
   curry(resolveAbstractionBranch(branches))

--- a/src/code_generation/util.ts
+++ b/src/code_generation/util.ts
@@ -8,8 +8,7 @@ const resolveAbstractionBranch = (branches: string[]) => {
   return `${RESOLVE_ABSTRACTION_BRANCH_FUNCTION}(${ARGUMENTS_NAME},[${joinedBranches}])`
 }
 
-const curry = (fn: string) =>
-  `${CURRY_FUNCTION}((...${ARGUMENTS_NAME})=>${fn})`
+const curry = (fn: string) => `${CURRY_FUNCTION}((...${ARGUMENTS_NAME})=>${fn})`
 
 export const generateAbstraction = (branches: string[]): string =>
   curry(resolveAbstractionBranch(branches))

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -11,7 +11,7 @@ import { writeEmit } from './emit'
 export const compile = async (
   entry: string,
   options: ConfigOptions,
-): Promise<AbsolutePath | Report> => {
+): Promise<{ out: AbsolutePath } | Report> => {
   const config = buildConfig(entry, options)
 
   log(config, LogLevel.Info, 'Compiling', config.entry.path)
@@ -25,5 +25,5 @@ export const compile = async (
   const emit = generateCode(config, typedGlobalScope)
   await writeEmit(config, emit)
 
-  return config.out
+  return { out: config.out }
 }

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -1,6 +1,8 @@
 import { ConfigOptions, buildConfig } from './config'
 import { LogLevel, log } from './logger'
+import { buildReport, reportHasError } from './errors'
 import { AbsolutePath } from './types/path'
+import { Report } from './types/errors/reports'
 import { analyze } from './analyze'
 import { generateCode } from './code_generation'
 import { inferTypes } from './type_inference'
@@ -9,13 +11,16 @@ import { writeEmit } from './emit'
 export const compile = async (
   entry: string,
   options: ConfigOptions,
-): Promise<AbsolutePath> => {
+): Promise<AbsolutePath | Report> => {
   const config = buildConfig(entry, options)
 
   log(config, LogLevel.Info, 'Compiling', config.entry.path)
 
   const globalScope = await analyze(config)
   const typedGlobalScope = inferTypes(config, globalScope)
+
+  const report = buildReport(typedGlobalScope)
+  if (reportHasError(report)) return Promise.reject<Report>(report)
 
   const emit = generateCode(config, typedGlobalScope)
   await writeEmit(config, emit)

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,9 @@ export type ConfigOptions = {
   verbose?: boolean
 }
 
+/**
+ * Constructs a config from a path to the entry file and some config options.
+ */
 export const buildConfig = (entry: string, options: ConfigOptions): Config => {
   const { out } = options
 

--- a/src/emit.ts
+++ b/src/emit.ts
@@ -4,6 +4,9 @@ import { Config } from './config'
 import { Emit } from './types/emit'
 import { buildAbsolutePath } from './types/path'
 
+/**
+ * Writes an emit to the file system.
+ */
 export const writeEmit = async (config: Config, emit: Emit): Promise<void> => {
   await Promise.all(
     emit.map(async ({ originalFile, content }) => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,12 +3,21 @@ import { GlobalScope } from './types/analyze/scopes'
 import { MountedErrorAnnotation } from './types/errors/annotations'
 import { Report } from './types/errors/reports'
 
+/**
+ * Collects all mounted errors of a recursive scope.
+ */
 export const collectErrors = (scope: AbstractScope): MountedErrorAnnotation[] =>
   [scope.errors, ...scope.scopes.map(collectErrors)].flat()
 
+/**
+ * Determines whether a recursive scope has any mounted errors.
+ */
 export const hasError = (scope: AbstractScope): boolean =>
   collectErrors(scope).length > 0
 
+/**
+ * Collects all errors of a global scope.
+ */
 export const buildReport = (scope: GlobalScope): Report => ({
   errors: scope.errors,
   mountedErrors: scope.scopes.map((fileScope) => ({
@@ -17,6 +26,9 @@ export const buildReport = (scope: GlobalScope): Report => ({
   })),
 })
 
+/**
+ * Determines whether a global scope has any immediate or mounted errors.
+ */
 export const reportHasError = (report: Report): boolean =>
   report.errors.length > 0 ||
   report.mountedErrors.some(({ errors }) => errors.length > 0)

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,8 +1,22 @@
 import { AbstractScope } from './types/state'
+import { GlobalScope } from './types/analyze/scopes'
 import { MountedErrorAnnotation } from './types/errors/annotations'
+import { Report } from './types/errors/reports'
 
 export const collectErrors = (scope: AbstractScope): MountedErrorAnnotation[] =>
   [scope.errors, ...scope.scopes.map(collectErrors)].flat()
 
 export const hasError = (scope: AbstractScope): boolean =>
   collectErrors(scope).length > 0
+
+export const buildReport = (scope: GlobalScope): Report => ({
+  errors: scope.errors,
+  mountedErrors: scope.scopes.map((fileScope) => [
+    fileScope.file,
+    collectErrors(fileScope),
+  ]),
+})
+
+export const reportHasError = (report: Report): boolean =>
+  report.errors.length > 0 ||
+  report.mountedErrors.some(([, errors]) => errors.length > 0)

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -11,12 +11,12 @@ export const hasError = (scope: AbstractScope): boolean =>
 
 export const buildReport = (scope: GlobalScope): Report => ({
   errors: scope.errors,
-  mountedErrors: scope.scopes.map((fileScope) => [
-    fileScope.file,
-    collectErrors(fileScope),
-  ]),
+  mountedErrors: scope.scopes.map((fileScope) => ({
+    file: fileScope.file,
+    errors: collectErrors(fileScope),
+  })),
 })
 
 export const reportHasError = (report: Report): boolean =>
   report.errors.length > 0 ||
-  report.mountedErrors.some(([, errors]) => errors.length > 0)
+  report.mountedErrors.some(({ errors }) => errors.length > 0)

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,3 @@
+/**
+ * This file includes shared library functions.
+ */

--- a/src/type_inference/index.ts
+++ b/src/type_inference/index.ts
@@ -34,8 +34,8 @@ import { addErrorUnless, traverseScopes } from '../util/traverse'
 import { filterFileScopeByTermScopes, findScopeOfNode } from '../util/scopes'
 import { mapAnswers, reduceAnswers } from '../util/answers'
 import { Config } from '../config'
+import { NonTypeNode } from '../types/nodes'
 import { ResolvedType } from '../types/type_inference/categories'
-import { TermNode } from '../types/nodes'
 import { TypeAssignment } from '../types/analyze/bindings'
 import { buildAmbiguousTypeError } from '../types/errors/annotations'
 import { buildTemporaryTypeVariable } from '../types/type_inference/types'
@@ -67,7 +67,7 @@ type State = {
  * Represents a type annotation (an "explanation") for a given node in the
  * syntax tree.
  */
-type Return<T extends TermNode = TermNode> = {
+type Return<T extends NonTypeNode = NonTypeNode> = {
   typedNode: TypedNode<T>
 }
 
@@ -131,7 +131,7 @@ const buildContext = (
   constraints: Constraints = buildConstraints(),
 ): Context => ({ type, constraints })
 
-const buildPrimitiveAnswer = <T extends TermNode>(
+const buildPrimitiveAnswer = <T extends NonTypeNode>(
   state: State,
   node: T,
   type: PrimitiveType,
@@ -141,7 +141,7 @@ const buildPrimitiveAnswer = <T extends TermNode>(
     typedNode: buildTypedNode(node, type, buildConstraints(), childNodes),
   })
 
-const wrapAnswer = <T extends TermNode, U extends TermNode>(
+const wrapAnswer = <T extends NonTypeNode, U extends NonTypeNode>(
   answer: Answer<State, { results: Return<U>[] }>,
   callback: (
     state: State,
@@ -228,7 +228,7 @@ const nest = <T extends NestingTermNode>(
   ])
 }
 
-const traverseAll = <T extends TermNode>(
+const traverseAll = <T extends NonTypeNode>(
   state: State,
   nodes: T[],
   buildConcreteContext: () => Context = buildContext,
@@ -245,7 +245,7 @@ const traverseAll = <T extends TermNode>(
     [buildAnswer(state, { results: [] })],
   )
 
-const ensureIsInstanceOf = <T extends TermNode>(
+const ensureIsInstanceOf = <T extends NonTypeNode>(
   answer: Answer<State, Return<T>>,
   { type, constraints }: Context,
 ): Answers<State, Return<T>> =>
@@ -262,7 +262,7 @@ const ensureIsInstanceOf = <T extends TermNode>(
       ),
   )
 
-const traverse = <T extends TermNode>(
+const traverse = <T extends NonTypeNode>(
   state: State,
   node: T,
   context: Context,
@@ -288,7 +288,7 @@ const traverse = <T extends TermNode>(
 
 const handleNode = (
   state: State,
-  node: TermNode,
+  node: NonTypeNode,
   context: Context,
 ): Answers<State, Return> => {
   switch (node.type) {

--- a/src/type_inference/index.ts
+++ b/src/type_inference/index.ts
@@ -441,6 +441,10 @@ const handleNode = (
       throw new NotImplementedError(
         'Tony cannot infer the type of right sections yet.',
       )
+    case SyntaxType.ShorthandAccessIdentifier:
+      throw new NotImplementedError(
+        'Tony cannot infer the type of shorthand access identifiers yet.',
+      )
     case SyntaxType.ShorthandMemberPattern:
       throw new NotImplementedError(
         'Tony cannot infer the type of shorthand member patterns yet.',

--- a/src/type_inference/index.ts
+++ b/src/type_inference/index.ts
@@ -461,6 +461,10 @@ const handleNode = (
       throw new NotImplementedError(
         'Tony cannot infer the type of shorthand member identifiers yet.',
       )
+    case SyntaxType.ShorthandMember:
+      throw new NotImplementedError(
+        'Tony cannot infer the type of shorthand members yet.',
+      )
     case SyntaxType.Spread:
       throw new NotImplementedError(
         'Tony cannot infer the type of spreads yet.',

--- a/src/type_inference/index.ts
+++ b/src/type_inference/index.ts
@@ -449,6 +449,10 @@ const handleNode = (
       throw new NotImplementedError(
         'Tony cannot infer the type of shorthand member patterns yet.',
       )
+    case SyntaxType.ShorthandMemberIdentifier:
+      throw new NotImplementedError(
+        'Tony cannot infer the type of shorthand member identifiers yet.',
+      )
     case SyntaxType.Spread:
       throw new NotImplementedError(
         'Tony cannot infer the type of spreads yet.',

--- a/src/types/analyze/bindings.ts
+++ b/src/types/analyze/bindings.ts
@@ -36,8 +36,8 @@ export type TermBindingNode =
 export type TypeBindingNode = EnumNode | InterfaceNode | TypeAliasNode
 
 type AbstractBinding = {
-  name: string
-  isExported: boolean
+  readonly name: string
+  readonly isExported: boolean
 }
 
 enum BindingKind {
@@ -47,23 +47,23 @@ enum BindingKind {
 }
 
 type AbstractTermBinding = AbstractBinding & {
-  kind: typeof BindingKind.Term
-  node: TermBindingNode
+  readonly kind: typeof BindingKind.Term
+  readonly node: TermBindingNode
   /**
    * The index tracks the number of times a binding is overloaded. Among all
    * bindings with a given name that have overlapping scopes, index is a unique
    * identifier.
    */
-  index: number
+  readonly index: number
   /**
    * A binding is implicit when it stems from a generator, parameter or case,
    * but not when it stems from an assignment. Used for code generation.
    */
-  isImplicit: boolean
+  readonly isImplicit: boolean
 }
 
 type AbstractTypeBinding = AbstractBinding & {
-  kind: typeof BindingKind.Type
+  readonly kind: typeof BindingKind.Type
 }
 
 enum BindingLocation {
@@ -72,13 +72,13 @@ enum BindingLocation {
 }
 
 export type ImportedBinding = {
-  location: typeof BindingLocation.Imported
-  file: AbsolutePath
-  originalName?: string
+  readonly location: typeof BindingLocation.Imported
+  readonly file: AbsolutePath
+  readonly originalName?: string
 }
 
 export type LocalBinding = {
-  location: typeof BindingLocation.Local
+  readonly location: typeof BindingLocation.Local
 }
 
 export type ImportedTermBinding = AbstractTermBinding & ImportedBinding
@@ -86,28 +86,28 @@ export type LocalTermBinding = AbstractTermBinding & LocalBinding
 export type TermBinding = ImportedTermBinding | LocalTermBinding
 
 export type ImportedTypeBinding = AbstractTypeBinding &
-  ImportedBinding & { node: ImportTypeNode }
+  ImportedBinding & { readonly node: ImportTypeNode }
 export type LocalTypeBinding = AbstractTypeBinding &
   LocalBinding & {
-    node: TypeBindingNode
-    value: DeclaredType
-    alias: Type
-    deferredAssignments: DeferredTypeVariableAssignment[]
+    readonly node: TypeBindingNode
+    readonly value: DeclaredType
+    readonly alias: Type
+    readonly deferredAssignments: DeferredTypeVariableAssignment[]
   }
 export type TypeBinding = ImportedTypeBinding | LocalTypeBinding
 
 export type TypeVariableBinding = AbstractBinding & {
-  kind: typeof BindingKind.TypeVariable
-  node: TypeVariableDeclarationNode
-  value: TypeVariable
-  constraints: Constraints<Type>
+  readonly kind: typeof BindingKind.TypeVariable
+  readonly node: TypeVariableDeclarationNode
+  readonly value: TypeVariable
+  readonly constraints: Constraints<Type>
 }
 
 /**
  * A type assignment assigns a type to a term binding.
  */
 export type TypeAssignment = TermBinding & {
-  type: ResolvedType
+  readonly type: ResolvedType
 }
 
 // ---- Factories ----

--- a/src/types/analyze/bindings.ts
+++ b/src/types/analyze/bindings.ts
@@ -204,10 +204,11 @@ export const buildTypeAssignment = (
   type,
 })
 
-export const isImportedBinding = (binding: {
-  location: BindingLocation
-}): binding is ImportedBinding => binding.location === BindingLocation.Imported
+export const isImportedBinding = <T extends TermBinding | TypeBinding>(
+  binding: T,
+): binding is T & ImportedBinding =>
+  binding.location === BindingLocation.Imported
 
-export const isLocalBinding = (binding: {
-  location: BindingLocation
-}): binding is LocalBinding => binding.location === BindingLocation.Local
+export const isLocalBinding = <T extends TermBinding | TypeBinding>(
+  binding: T,
+): binding is T & LocalBinding => binding.location === BindingLocation.Local

--- a/src/types/analyze/scopes.ts
+++ b/src/types/analyze/scopes.ts
@@ -12,6 +12,7 @@ import {
   WhenNode,
 } from 'tree-sitter-tony'
 import { ErrorAnnotation, MountedErrorAnnotation } from '../errors/annotations'
+import { NonTypeNode, TermNode } from '../nodes'
 import {
   TermBinding,
   TypeAssignment,
@@ -19,7 +20,6 @@ import {
   TypeVariableBinding,
 } from './bindings'
 import { AbsolutePath } from '../path'
-import { TermNode } from '../nodes'
 import { TypedNode } from '../type_inference/nodes'
 
 // ---- Types ----
@@ -63,7 +63,7 @@ export type ScopeWithNode<T extends SyntaxNode> = {
   readonly node: T
 }
 
-export type TypedScope<T extends TermNode> = {
+export type TypedScope<T extends NonTypeNode> = {
   readonly typedNode: TypedNode<T>
 }
 

--- a/src/types/analyze/scopes.ts
+++ b/src/types/analyze/scopes.ts
@@ -72,7 +72,7 @@ export type RecursiveScope<T> = {
 }
 
 export type GlobalScope<
-  T extends FileScope | TypedFileScope
+  T extends FileScope | TypedFileScope = FileScope | TypedFileScope
 > = RecursiveScope<T> & {
   readonly kind: typeof ScopeKind.Global
   readonly errors: ErrorAnnotation[]

--- a/src/types/analyze/scopes.ts
+++ b/src/types/analyze/scopes.ts
@@ -40,35 +40,35 @@ enum ScopeKind {
 }
 
 export type ScopeWithTerms = {
-  terms: TermBinding[]
+  readonly terms: TermBinding[]
 }
 
 export type TypingEnvironment = {
-  typeAssignments: TypeAssignment[]
+  readonly typeAssignments: TypeAssignment[]
 }
 
 export type ScopeWithTypes = {
-  types: TypeBinding[]
-  typeVariables: TypeVariableBinding[]
+  readonly types: TypeBinding[]
+  readonly typeVariables: TypeVariableBinding[]
 }
 
 export type ScopeWithErrors = {
-  errors: MountedErrorAnnotation[]
+  readonly errors: MountedErrorAnnotation[]
 }
 
 export type TypedScope<T extends TermNode> = {
-  typedNode: TypedNode<T>
+  readonly typedNode: TypedNode<T>
 }
 
 export type RecursiveScope<T> = {
-  scopes: T[]
+  readonly scopes: T[]
 }
 
 export type GlobalScope<
   T extends FileScope | TypedFileScope
 > = RecursiveScope<T> & {
-  kind: typeof ScopeKind.Global
-  errors: ErrorAnnotation[]
+  readonly kind: typeof ScopeKind.Global
+  readonly errors: ErrorAnnotation[]
 }
 
 export type FileScope<T extends NestingNode = NestingNode> = RecursiveScope<
@@ -77,10 +77,10 @@ export type FileScope<T extends NestingNode = NestingNode> = RecursiveScope<
   ScopeWithTerms &
   ScopeWithTypes &
   ScopeWithErrors & {
-    kind: typeof ScopeKind.File
-    file: AbsolutePath
-    node: ProgramNode
-    dependencies: AbsolutePath[]
+    readonly kind: typeof ScopeKind.File
+    readonly file: AbsolutePath
+    readonly node: ProgramNode
+    readonly dependencies: AbsolutePath[]
   }
 
 export type TypedFileScope = FileScope &
@@ -93,15 +93,15 @@ export interface NestedScope<T extends NestingNode = NestingNode>
     ScopeWithTerms,
     ScopeWithTypes,
     ScopeWithErrors {
-  kind: typeof ScopeKind.Nested
-  node: T
+  readonly kind: typeof ScopeKind.Nested
+  readonly node: T
 }
 
 export interface TypedNestedScope<T extends NestingTermNode = NestingTermNode>
   extends NestedScope<T>,
     TypingEnvironment,
     TypedScope<T> {
-  scopes: TypedNestedScope<T>[]
+  readonly scopes: TypedNestedScope<T>[]
 }
 
 // ---- Factories ----

--- a/src/types/cyclic_dependency.ts
+++ b/src/types/cyclic_dependency.ts
@@ -3,7 +3,7 @@
  * ancestors of a.
  */
 export type CyclicDependency<T> = {
-  a: T
-  b: T
-  ancestorsOfA: T[]
+  readonly a: T
+  readonly b: T
+  readonly ancestorsOfA: T[]
 }

--- a/src/types/emit.ts
+++ b/src/types/emit.ts
@@ -1,8 +1,17 @@
 import { AbsolutePath } from './path'
 
-type FileEmit = {
+// ---- Types ----
+
+export type FileEmit = {
   originalFile: AbsolutePath
   content: string
 }
 
 export type Emit = FileEmit[]
+
+// ---- Factories ----
+
+export const buildFileEmit = (
+  originalFile: AbsolutePath,
+  content: string,
+): FileEmit => ({ originalFile, content })

--- a/src/types/emit.ts
+++ b/src/types/emit.ts
@@ -3,8 +3,8 @@ import { AbsolutePath } from './path'
 // ---- Types ----
 
 export type FileEmit = {
-  originalFile: AbsolutePath
-  content: string
+  readonly originalFile: AbsolutePath
+  readonly content: string
 }
 
 export type Emit = FileEmit[]

--- a/src/types/errors/annotations.ts
+++ b/src/types/errors/annotations.ts
@@ -27,79 +27,79 @@ export enum ErrorAnnotationKind {
 }
 
 export type CyclicDependencyError = {
-  kind: typeof ErrorAnnotationKind.CyclicDependency
-  cyclicDependency: CyclicDependency<AbsolutePath>
+  readonly kind: typeof ErrorAnnotationKind.CyclicDependency
+  readonly cyclicDependency: CyclicDependency<AbsolutePath>
 }
 
 export type DuplicateBindingError = {
-  kind: typeof ErrorAnnotationKind.DuplicateBinding
-  name: string
+  readonly kind: typeof ErrorAnnotationKind.DuplicateBinding
+  readonly name: string
 }
 
 export type ExportOutsideFileScopeError = {
-  kind: typeof ErrorAnnotationKind.ExportOutsideFileScope
+  readonly kind: typeof ErrorAnnotationKind.ExportOutsideFileScope
 }
 
 export type ExternalTypeImportError = {
-  kind: typeof ErrorAnnotationKind.ExternalTypeImport
+  readonly kind: typeof ErrorAnnotationKind.ExternalTypeImport
 }
 
 export type ImportOutsideFileScopeError = {
-  kind: typeof ErrorAnnotationKind.ImportOutsideFileScope
+  readonly kind: typeof ErrorAnnotationKind.ImportOutsideFileScope
 }
 
 export type IncompleteWhenPatternError = {
-  kind: typeof ErrorAnnotationKind.IncompleteWhenPattern
-  missingBindings: string[]
+  readonly kind: typeof ErrorAnnotationKind.IncompleteWhenPattern
+  readonly missingBindings: string[]
 }
 
 export type AmbiguousTypeError = {
-  kind: typeof ErrorAnnotationKind.AmbiguousType
-  answers: TypedNode<ProgramNode>[]
+  readonly kind: typeof ErrorAnnotationKind.AmbiguousType
+  readonly answers: TypedNode<ProgramNode>[]
 }
 
 export type MissingBindingError = {
-  kind: typeof ErrorAnnotationKind.MissingBinding
-  name: string
+  readonly kind: typeof ErrorAnnotationKind.MissingBinding
+  readonly name: string
 }
 
 export type MissingExternalImportTypeHintError = {
-  kind: typeof ErrorAnnotationKind.MissingExternalImportTypeHint
-  binding: TermBinding
+  readonly kind: typeof ErrorAnnotationKind.MissingExternalImportTypeHint
+  readonly binding: TermBinding
 }
 
 export type PrimitiveTypeArgumentsError = {
-  kind: typeof ErrorAnnotationKind.PrimitiveTypeArguments
+  readonly kind: typeof ErrorAnnotationKind.PrimitiveTypeArguments
 }
 
 export type RefinementTypeDeclarationOutsideRefinementTypeError = {
-  kind: typeof ErrorAnnotationKind.RefinementTypeDeclarationOutsideRefinementType
+  readonly kind: typeof ErrorAnnotationKind.RefinementTypeDeclarationOutsideRefinementType
 }
 
 export type TypeError = {
-  kind: typeof ErrorAnnotationKind.Type
-  expected: Type
-  actual: Type
+  readonly kind: typeof ErrorAnnotationKind.Type
+  readonly expected: Type
+  readonly actual: Type
 }
 
 export type UnknownFileError = {
-  kind: typeof ErrorAnnotationKind.UnknownFile
-  sourcePath: AbsolutePath | RelativePath
+  readonly kind: typeof ErrorAnnotationKind.UnknownFile
+  readonly sourcePath: AbsolutePath | RelativePath
 }
 
 export type UnknownImportError = {
-  kind: typeof ErrorAnnotationKind.UnknownImport
-  sourcePath: AbsolutePath
-  name: string
+  readonly kind: typeof ErrorAnnotationKind.UnknownImport
+  readonly sourcePath: AbsolutePath
+  readonly name: string
 }
 
 export type UnsupportedSyntaxError = {
-  kind: typeof ErrorAnnotationKind.UnsupportedSyntax
+  readonly kind: typeof ErrorAnnotationKind.UnsupportedSyntax
 }
 
 export type UseOfTypeAsValueError = {
-  kind: typeof ErrorAnnotationKind.UseOfTypeAsValue
-  type: Type
+  readonly kind: typeof ErrorAnnotationKind.UseOfTypeAsValue
+  readonly type: Type
 }
 
 export type ErrorAnnotation =

--- a/src/types/errors/reports.ts
+++ b/src/types/errors/reports.ts
@@ -2,6 +2,6 @@ import { ErrorAnnotation, MountedErrorAnnotation } from './annotations'
 import { AbsolutePath } from '../path'
 
 export type Report = {
-  errors: ErrorAnnotation[]
-  mountedErrors: [file: AbsolutePath, errors: MountedErrorAnnotation[]][]
+  readonly errors: ErrorAnnotation[]
+  readonly mountedErrors: [file: AbsolutePath, errors: MountedErrorAnnotation[]][]
 }

--- a/src/types/errors/reports.ts
+++ b/src/types/errors/reports.ts
@@ -1,7 +1,12 @@
 import { ErrorAnnotation, MountedErrorAnnotation } from './annotations'
 import { AbsolutePath } from '../path'
 
+type FileReport = {
+  readonly file: AbsolutePath
+  readonly errors: MountedErrorAnnotation[]
+}
+
 export type Report = {
   readonly errors: ErrorAnnotation[]
-  readonly mountedErrors: [file: AbsolutePath, errors: MountedErrorAnnotation[]][]
+  readonly mountedErrors: FileReport[]
 }

--- a/src/types/errors/reports.ts
+++ b/src/types/errors/reports.ts
@@ -1,0 +1,7 @@
+import { ErrorAnnotation, MountedErrorAnnotation } from './annotations'
+import { AbsolutePath } from '../path'
+
+export type Report = {
+  errors: ErrorAnnotation[]
+  mountedErrors: [file: AbsolutePath, errors: MountedErrorAnnotation[]][]
+}

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -1,0 +1,114 @@
+import {
+  AbstractionBranchNode,
+  AbstractionNode,
+  AccessNode,
+  ApplicationNode,
+  ArgumentNode,
+  AssignmentNode,
+  BlockNode,
+  BooleanNode,
+  CaseNode,
+  DestructuringPatternNode,
+  ElseIfNode,
+  EnumNode,
+  EnumValueNode,
+  ErrorNode,
+  ExportNode,
+  ExportedImportNode,
+  GeneratorNode,
+  GroupNode,
+  IdentifierNode,
+  IdentifierPatternNode,
+  IfNode,
+  ImportIdentifierNode,
+  ImportNode,
+  ImportTypeNode,
+  InfixApplicationNode,
+  InterfaceNode,
+  InterpolationNode,
+  LeftSectionNode,
+  ListComprehensionNode,
+  ListNode,
+  ListPatternNode,
+  MemberNode,
+  MemberPatternNode,
+  NumberNode,
+  PatternGroupNode,
+  PipelineNode,
+  PrefixApplicationNode,
+  ProgramNode,
+  RawStringNode,
+  RegexNode,
+  RestNode,
+  ReturnNode,
+  RightSectionNode,
+  ShorthandMemberPatternNode,
+  SpreadNode,
+  StringNode,
+  StructNode,
+  StructPatternNode,
+  TaggedPatternNode,
+  TaggedValueNode,
+  TupleNode,
+  TuplePatternNode,
+  TypeAliasNode,
+  TypeHintNode,
+  WhenNode,
+} from 'tree-sitter-tony'
+
+export type TermNode =
+  | AbstractionNode
+  | AbstractionBranchNode
+  | AccessNode
+  | ApplicationNode
+  | ArgumentNode
+  | AssignmentNode
+  | BlockNode
+  | BooleanNode
+  | CaseNode
+  | DestructuringPatternNode
+  | ElseIfNode
+  | EnumNode
+  | EnumValueNode
+  | ExportNode
+  | ExportedImportNode
+  | GeneratorNode
+  | GroupNode
+  | IdentifierNode
+  | IdentifierPatternNode
+  | IfNode
+  | ImportNode
+  | ImportIdentifierNode
+  | ImportTypeNode
+  | InfixApplicationNode
+  | InterfaceNode
+  | InterpolationNode
+  | LeftSectionNode
+  | ListNode
+  | ListComprehensionNode
+  | ListPatternNode
+  | MemberNode
+  | MemberPatternNode
+  | NumberNode
+  | PatternGroupNode
+  | PipelineNode
+  | PrefixApplicationNode
+  | ProgramNode
+  | RawStringNode
+  | RegexNode
+  | RestNode
+  | ReturnNode
+  | RightSectionNode
+  | ShorthandMemberPatternNode
+  | SpreadNode
+  | StringNode
+  | StructNode
+  | StructPatternNode
+  | TaggedPatternNode
+  | TaggedValueNode
+  | TupleNode
+  | TuplePatternNode
+  | TypeAliasNode
+  | TypeHintNode
+  | WhenNode
+  | ErrorNode

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -42,6 +42,7 @@ import {
   RestNode,
   ReturnNode,
   RightSectionNode,
+  ShorthandAccessIdentifierNode,
   ShorthandMemberPatternNode,
   SpreadNode,
   StringNode,
@@ -99,6 +100,7 @@ export type TermNode =
   | RestNode
   | ReturnNode
   | RightSectionNode
+  | ShorthandAccessIdentifierNode
   | ShorthandMemberPatternNode
   | SpreadNode
   | StringNode

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -43,6 +43,7 @@ import {
   ReturnNode,
   RightSectionNode,
   ShorthandAccessIdentifierNode,
+  ShorthandMemberIdentifierNode,
   ShorthandMemberPatternNode,
   SpreadNode,
   StringNode,
@@ -101,6 +102,7 @@ export type TermNode =
   | ReturnNode
   | RightSectionNode
   | ShorthandAccessIdentifierNode
+  | ShorthandMemberIdentifierNode
   | ShorthandMemberPatternNode
   | SpreadNode
   | StringNode

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -44,6 +44,7 @@ import {
   RightSectionNode,
   ShorthandAccessIdentifierNode,
   ShorthandMemberIdentifierNode,
+  ShorthandMemberNode,
   ShorthandMemberPatternNode,
   SpreadNode,
   StringNode,
@@ -96,6 +97,7 @@ export type TermNode =
   | RightSectionNode
   | ShorthandAccessIdentifierNode
   | ShorthandMemberIdentifierNode
+  | ShorthandMemberNode
   | SpreadNode
   | StringNode
   | StructNode

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -59,7 +59,7 @@ import {
   WhenNode,
 } from 'tree-sitter-tony'
 
-type LiteralNode = BooleanNode | NumberNode | RawStringNode | RegexNode
+export type LiteralNode = BooleanNode | NumberNode | RawStringNode | RegexNode
 
 export type TermNode =
   | LiteralNode

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -56,7 +56,7 @@ import {
   WhenNode,
 } from 'tree-sitter-tony'
 
-export type TermNodeWithoutError =
+export type TermNode =
   | AbstractionNode
   | AbstractionBranchNode
   | AccessNode
@@ -112,4 +112,4 @@ export type TermNodeWithoutError =
   | TypeHintNode
   | WhenNode
 
-export type TermNode = TermNodeWithoutError | ErrorNode
+export type NonTypeNode = TermNode | ErrorNode

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -58,7 +58,10 @@ import {
   WhenNode,
 } from 'tree-sitter-tony'
 
+type LiteralNode = BooleanNode | NumberNode | RawStringNode | RegexNode
+
 export type TermNode =
+  | LiteralNode
   | AbstractionNode
   | AbstractionBranchNode
   | AccessNode
@@ -66,9 +69,7 @@ export type TermNode =
   | ArgumentNode
   | AssignmentNode
   | BlockNode
-  | BooleanNode
   | CaseNode
-  | DestructuringPatternNode
   | ElseIfNode
   | EnumNode
   | EnumValueNode
@@ -77,7 +78,6 @@ export type TermNode =
   | GeneratorNode
   | GroupNode
   | IdentifierNode
-  | IdentifierPatternNode
   | IfNode
   | ImportNode
   | ImportIdentifierNode
@@ -88,32 +88,34 @@ export type TermNode =
   | LeftSectionNode
   | ListNode
   | ListComprehensionNode
-  | ListPatternNode
   | MemberNode
-  | MemberPatternNode
-  | NumberNode
-  | PatternGroupNode
   | PipelineNode
   | PrefixApplicationNode
   | ProgramNode
-  | RawStringNode
-  | RegexNode
-  | RestNode
   | ReturnNode
   | RightSectionNode
   | ShorthandAccessIdentifierNode
   | ShorthandMemberIdentifierNode
-  | ShorthandMemberPatternNode
   | SpreadNode
   | StringNode
   | StructNode
-  | StructPatternNode
-  | TaggedPatternNode
   | TaggedValueNode
   | TupleNode
-  | TuplePatternNode
   | TypeAliasNode
   | TypeHintNode
   | WhenNode
 
-export type NonTypeNode = TermNode | ErrorNode
+export type PatternNode =
+  | LiteralNode
+  | DestructuringPatternNode
+  | IdentifierPatternNode
+  | ListPatternNode
+  | MemberPatternNode
+  | PatternGroupNode
+  | RestNode
+  | ShorthandMemberPatternNode
+  | StructPatternNode
+  | TaggedPatternNode
+  | TuplePatternNode
+
+export type NonTypeNode = TermNode | PatternNode | ErrorNode

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -56,7 +56,7 @@ import {
   WhenNode,
 } from 'tree-sitter-tony'
 
-export type TermNode =
+export type TermNodeWithoutError =
   | AbstractionNode
   | AbstractionBranchNode
   | AccessNode
@@ -111,4 +111,5 @@ export type TermNode =
   | TypeAliasNode
   | TypeHintNode
   | WhenNode
-  | ErrorNode
+
+export type TermNode = TermNodeWithoutError | ErrorNode

--- a/src/types/path.ts
+++ b/src/types/path.ts
@@ -8,14 +8,14 @@ enum PathKind {
 }
 
 export type AbsolutePath = {
-  kind: typeof PathKind.Absolute
-  path: string
+  readonly kind: typeof PathKind.Absolute
+  readonly path: string
 }
 
 export type RelativePath = {
-  kind: typeof PathKind.Relative
-  path: string
-  mount: AbsolutePath
+  readonly kind: typeof PathKind.Relative
+  readonly path: string
+  readonly mount: AbsolutePath
 }
 
 export type Path = AbsolutePath | RelativePath

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -4,6 +4,6 @@ export interface AbstractScope
   extends ScopeWithErrors,
     RecursiveScope<AbstractScope> {}
 
-export type AbstractState = {
-  readonly scopes: AbstractScope[]
+export type AbstractState<T extends AbstractScope = AbstractScope> = {
+  readonly scopes: T[]
 }

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -5,5 +5,5 @@ export interface AbstractScope
     RecursiveScope<AbstractScope> {}
 
 export type AbstractState = {
-  scopes: AbstractScope[]
+  readonly scopes: AbstractScope[]
 }

--- a/src/types/type_inference/answers.ts
+++ b/src/types/type_inference/answers.ts
@@ -4,7 +4,7 @@
  * An answer represents a single "explanation".
  */
 export type Answer<T, U> = {
-  state: T
+  readonly state: T
 } & U
 
 /**

--- a/src/types/type_inference/constraints.ts
+++ b/src/types/type_inference/constraints.ts
@@ -8,16 +8,16 @@ import { TypeVariable } from './types'
  * A set of assignments of type variables to their most general type.
  */
 export type Constraints<T extends Type = ResolvedType> = {
-  assignments: TypeVariableAssignment<T>[]
-  deferredAssignments: DeferredTypeVariableAssignment[]
+  readonly assignments: TypeVariableAssignment<T>[]
+  readonly deferredAssignments: DeferredTypeVariableAssignment[]
 }
 
 /**
  * Maps a set of type variables to their most general type (if any).
  */
 export type TypeVariableAssignment<T extends Type = ResolvedType> = {
-  typeVariables: TypeVariable[]
-  type?: T
+  readonly typeVariables: TypeVariable[]
+  readonly type?: T
 }
 
 /**
@@ -26,8 +26,8 @@ export type TypeVariableAssignment<T extends Type = ResolvedType> = {
  * was determined.
  */
 export type DeferredTypeVariableAssignment = {
-  typeVariable: TypeVariable
-  bindings: TermBinding[]
+  readonly typeVariable: TypeVariable
+  readonly bindings: TermBinding[]
 }
 
 // ---- Factories ----

--- a/src/types/type_inference/nodes.ts
+++ b/src/types/type_inference/nodes.ts
@@ -1,5 +1,5 @@
+import { IdentifierNode, ShorthandAccessIdentifierNode } from 'tree-sitter-tony'
 import { Constraints } from './constraints'
-import { IdentifierNode } from 'tree-sitter-tony'
 import { NonTypeNode } from '../nodes'
 import { ResolvedType } from './categories'
 import { TermBinding } from '../analyze/bindings'
@@ -34,9 +34,11 @@ export type TypedNodeChildren<T extends NonTypeNode> = Omit<
 /**
  * Extensions to the typed node of certain node types.
  */
-export type TypedNodeExtensions<
-  T extends NonTypeNode
-> = T extends IdentifierNode ? { binding: TermBinding } : {}
+export type TypedNodeExtensions<T extends NonTypeNode> = T extends
+  | IdentifierNode
+  | ShorthandAccessIdentifierNode
+  ? { binding: TermBinding }
+  : {}
 
 /**
  * A type annotation for a given node in the syntax tree.

--- a/src/types/type_inference/nodes.ts
+++ b/src/types/type_inference/nodes.ts
@@ -1,6 +1,8 @@
 import { Constraints } from './constraints'
+import { IdentifierNode } from 'tree-sitter-tony'
 import { NonTypeNode } from '../nodes'
 import { ResolvedType } from './categories'
+import { TermBinding } from '../analyze/bindings'
 
 // ---- Types ----
 
@@ -30,13 +32,21 @@ export type TypedNodeChildren<T extends NonTypeNode> = Omit<
 >
 
 /**
+ * Extensions to the typed node of certain node types.
+ */
+export type TypedNodeExtensions<
+  T extends NonTypeNode
+> = T extends IdentifierNode ? { binding: TermBinding } : {}
+
+/**
  * A type annotation for a given node in the syntax tree.
  */
-export type TypedNode<T extends NonTypeNode> = TypedNodeChildren<T> & {
-  readonly node: T
-  readonly type: ResolvedType
-  readonly constraints: Constraints
-}
+export type TypedNode<T extends NonTypeNode> = TypedNodeChildren<T> &
+  TypedNodeExtensions<T> & {
+    readonly node: T
+    readonly type: ResolvedType
+    readonly constraints: Constraints
+  }
 
 // ---- Factories ----
 
@@ -45,9 +55,11 @@ export const buildTypedNode = <T extends NonTypeNode>(
   type: ResolvedType,
   constraints: Constraints,
   childNodes: TypedNodeChildren<T>,
+  extensions: TypedNodeExtensions<T>,
 ): TypedNode<T> => ({
   ...childNodes,
   node,
   type,
   constraints,
+  ...extensions,
 })

--- a/src/types/type_inference/nodes.ts
+++ b/src/types/type_inference/nodes.ts
@@ -1,4 +1,4 @@
-import { IdentifierNode, ShorthandAccessIdentifierNode } from 'tree-sitter-tony'
+import { IdentifierNode, ShorthandMemberNode } from 'tree-sitter-tony'
 import { Constraints } from './constraints'
 import { NonTypeNode } from '../nodes'
 import { ResolvedType } from './categories'
@@ -36,7 +36,7 @@ export type TypedNodeChildren<T extends NonTypeNode> = Omit<
  */
 export type TypedNodeExtensions<T extends NonTypeNode> = T extends
   | IdentifierNode
-  | ShorthandAccessIdentifierNode
+  | ShorthandMemberNode
   ? { binding: TermBinding }
   : {}
 

--- a/src/types/type_inference/nodes.ts
+++ b/src/types/type_inference/nodes.ts
@@ -31,9 +31,9 @@ export type TypedNodeChildren<T extends TermNode> = Omit<
  * A type annotation for a given node in the syntax tree.
  */
 export type TypedNode<T extends TermNode> = TypedNodeChildren<T> & {
-  node: T
-  type: ResolvedType
-  constraints: Constraints
+  readonly node: T
+  readonly type: ResolvedType
+  readonly constraints: Constraints
 }
 
 // ---- Factories ----

--- a/src/types/type_inference/nodes.ts
+++ b/src/types/type_inference/nodes.ts
@@ -1,20 +1,20 @@
 import { Constraints } from './constraints'
+import { NonTypeNode } from '../nodes'
 import { ResolvedType } from './categories'
-import { TermNode } from '../nodes'
 
 // ---- Types ----
 
 type ExtractKeysOfValueType<T, K> = {
   [I in keyof T]: T[I] extends K ? I : never
 }[keyof T]
-type TypedNodeChildrenWithNever<T extends TermNode> = {
-  [P in keyof T]: T[P] extends TermNode
+type TypedNodeChildrenWithNever<T extends NonTypeNode> = {
+  [P in keyof T]: T[P] extends NonTypeNode
     ? TypedNode<T[P]>
-    : T[P] extends TermNode[]
+    : T[P] extends NonTypeNode[]
     ? TypedNode<T[P][0]>[]
     : never
 }
-type TypedNodeChildrenNeverKeys<T extends TermNode> = ExtractKeysOfValueType<
+type TypedNodeChildrenNeverKeys<T extends NonTypeNode> = ExtractKeysOfValueType<
   TypedNodeChildrenWithNever<T>,
   never
 >
@@ -22,7 +22,7 @@ type TypedNodeChildrenNeverKeys<T extends TermNode> = ExtractKeysOfValueType<
 /**
  * Type annotations for all node children (that are term nodes).
  */
-export type TypedNodeChildren<T extends TermNode> = Omit<
+export type TypedNodeChildren<T extends NonTypeNode> = Omit<
   TypedNodeChildrenWithNever<T>,
   TypedNodeChildrenNeverKeys<T>
 >
@@ -30,7 +30,8 @@ export type TypedNodeChildren<T extends TermNode> = Omit<
 /**
  * A type annotation for a given node in the syntax tree.
  */
-export type TypedNode<T extends TermNode> = TypedNodeChildren<T> & {
+export type TypedNode<T extends NonTypeNode> = TypedNodeChildren<T> & {
+  readonly kind: T['type']
   readonly node: T
   readonly type: ResolvedType
   readonly constraints: Constraints
@@ -38,13 +39,14 @@ export type TypedNode<T extends TermNode> = TypedNodeChildren<T> & {
 
 // ---- Factories ----
 
-export const buildTypedNode = <T extends TermNode>(
+export const buildTypedNode = <T extends NonTypeNode>(
   node: T,
   type: ResolvedType,
   constraints: Constraints,
   childNodes: TypedNodeChildren<T>,
 ): TypedNode<T> => ({
   ...childNodes,
+  kind: node.type,
   node,
   type,
   constraints,

--- a/src/types/type_inference/nodes.ts
+++ b/src/types/type_inference/nodes.ts
@@ -1,29 +1,51 @@
 import { Constraints } from './constraints'
 import { ResolvedType } from './categories'
-import { SyntaxNode } from 'tree-sitter-tony'
+import { TermNode } from '../nodes'
 
 // ---- Types ----
+
+type ExtractKeysOfValueType<T, K> = {
+  [I in keyof T]: T[I] extends K ? I : never
+}[keyof T]
+type TypedNodeChildrenWithNever<T extends TermNode> = {
+  [P in keyof T]: T[P] extends TermNode
+    ? TypedNode<T[P]>
+    : T[P] extends TermNode[]
+    ? TypedNode<T[P][0]>[]
+    : never
+}
+type TypedNodeChildrenNeverKeys<T extends TermNode> = ExtractKeysOfValueType<
+  TypedNodeChildrenWithNever<T>,
+  never
+>
+
+/**
+ * Type annotations for all node children (that are term nodes).
+ */
+export type TypedNodeChildren<T extends TermNode> = Omit<
+  TypedNodeChildrenWithNever<T>,
+  TypedNodeChildrenNeverKeys<T>
+>
 
 /**
  * A type annotation for a given node in the syntax tree.
  */
-export type TypedNode<T extends SyntaxNode> = {
+export type TypedNode<T extends TermNode> = TypedNodeChildren<T> & {
   node: T
   type: ResolvedType
   constraints: Constraints
-  childNodes: TypedNode<SyntaxNode>[]
 }
 
 // ---- Factories ----
 
-export const buildTypedNode = <T extends SyntaxNode>(
+export const buildTypedNode = <T extends TermNode>(
   node: T,
   type: ResolvedType,
   constraints: Constraints,
-  childNodes: TypedNode<SyntaxNode>[] = [],
+  childNodes: TypedNodeChildren<T>,
 ): TypedNode<T> => ({
+  ...childNodes,
   node,
   type,
   constraints,
-  childNodes,
 })

--- a/src/types/type_inference/nodes.ts
+++ b/src/types/type_inference/nodes.ts
@@ -10,6 +10,8 @@ type ExtractKeysOfValueType<T, K> = {
 type TypedNodeChildrenWithNever<T extends NonTypeNode> = {
   [P in keyof T]: T[P] extends NonTypeNode
     ? TypedNode<T[P]>
+    : T[P] extends NonTypeNode | undefined
+    ? TypedNode<T[P] & object> | undefined // NonNullable<T[P]> doesn't work here
     : T[P] extends NonTypeNode[]
     ? TypedNode<T[P][0]>[]
     : never
@@ -31,7 +33,6 @@ export type TypedNodeChildren<T extends NonTypeNode> = Omit<
  * A type annotation for a given node in the syntax tree.
  */
 export type TypedNode<T extends NonTypeNode> = TypedNodeChildren<T> & {
-  readonly kind: T['type']
   readonly node: T
   readonly type: ResolvedType
   readonly constraints: Constraints
@@ -46,7 +47,6 @@ export const buildTypedNode = <T extends NonTypeNode>(
   childNodes: TypedNodeChildren<T>,
 ): TypedNode<T> => ({
   ...childNodes,
-  kind: node.type,
   node,
   type,
   constraints,

--- a/src/types/type_inference/nodes.ts
+++ b/src/types/type_inference/nodes.ts
@@ -20,7 +20,7 @@ type TypedNodeChildrenWithNever<T extends NonTypeNode> = {
 }
 type TypedNodeChildrenNeverKeys<T extends NonTypeNode> = ExtractKeysOfValueType<
   TypedNodeChildrenWithNever<T>,
-  never
+  never | undefined
 >
 
 /**

--- a/src/types/type_inference/predicates.ts
+++ b/src/types/type_inference/predicates.ts
@@ -8,13 +8,13 @@ enum ValueKind {
 }
 
 type BindingValue = {
-  kind: typeof ValueKind.Binding
-  name: string
+  readonly kind: typeof ValueKind.Binding
+  readonly name: string
 }
 
 type LiteralValue<T extends Literal> = {
-  kind: typeof ValueKind.Literal
-  value: T
+  readonly kind: typeof ValueKind.Literal
+  readonly value: T
 }
 
 type Value = BindingValue | LiteralValue<Literal>
@@ -24,8 +24,8 @@ type Value = BindingValue | LiteralValue<Literal>
  * boolean value.
  */
 export type Predicate = {
-  name: string
-  arguments: Value[]
+  readonly name: string
+  readonly arguments: Value[]
 }
 
 // ---- Constants ----

--- a/src/types/type_inference/primitive_types.ts
+++ b/src/types/type_inference/primitive_types.ts
@@ -5,26 +5,26 @@ import { TypeKind } from './types'
 export type Literal = string | number | boolean | RegExp
 
 type BooleanType = {
-  kind: typeof TypeKind.Boolean
+  readonly kind: typeof TypeKind.Boolean
 }
 
 type NumberType = {
-  kind: typeof TypeKind.Number
+  readonly kind: typeof TypeKind.Number
 }
 
 type RegExpType = {
-  kind: typeof TypeKind.RegExp
+  readonly kind: typeof TypeKind.RegExp
 }
 
 type StringType = {
-  kind: typeof TypeKind.String
+  readonly kind: typeof TypeKind.String
 }
 
 /**
  * The type of operations that do not return anything.
  */
 type VoidType = {
-  kind: typeof TypeKind.Void
+  readonly kind: typeof TypeKind.Void
 }
 
 export type PrimitiveType =

--- a/src/types/type_inference/types.ts
+++ b/src/types/type_inference/types.ts
@@ -9,8 +9,8 @@ import { flattenType } from '../../util/types'
  * A property represents the mapping of a key to a value.
  */
 export type Property<T extends Type = Type> = {
-  key: T
-  value: T
+  readonly key: T
+  readonly value: T
 }
 
 export enum TypeKind {
@@ -42,9 +42,9 @@ export enum TypeKind {
  * An access type reduces to the type a property of an object type maps to.
  */
 export interface AccessType {
-  kind: typeof TypeKind.Access
-  type: Type
-  property: Type
+  readonly kind: typeof TypeKind.Access
+  readonly type: Type
+  readonly property: Type
 }
 
 /**
@@ -52,11 +52,11 @@ export interface AccessType {
  * type fulfills some constraints.
  */
 export interface ConditionalType {
-  kind: typeof TypeKind.Conditional
-  type: Type
-  constraints: Type[]
-  consequence: Type
-  alternative: Type
+  readonly kind: typeof TypeKind.Conditional
+  readonly type: Type
+  readonly constraints: Type[]
+  readonly consequence: Type
+  readonly alternative: Type
 }
 
 /**
@@ -64,24 +64,24 @@ export interface ConditionalType {
  * returning the `to` type.
  */
 export interface CurriedType<T extends Type = Type> {
-  kind: typeof TypeKind.Curried
-  from: T
-  to: T
+  readonly kind: typeof TypeKind.Curried
+  readonly from: T
+  readonly to: T
   /**
    * A curried type is external when it represents an uncurried function
    * imported from JavaScript. Before values of this type are used, they should
    * be curried.
    */
-  isExternal: boolean
+  readonly isExternal: boolean
 }
 
 /**
  * A generic type represents a type that may depend on other types.
  */
 export interface GenericType {
-  kind: typeof TypeKind.Generic
-  name: string
-  typeParameters: TypeVariable[]
+  readonly kind: typeof TypeKind.Generic
+  readonly name: string
+  readonly typeParameters: TypeVariable[]
 }
 
 /**
@@ -89,8 +89,8 @@ export interface GenericType {
  * to be an instance of an interface.
  */
 export interface InterfaceType<T extends Type = Type> {
-  kind: typeof TypeKind.Interface
-  members: Property<T>[]
+  readonly kind: typeof TypeKind.Interface
+  readonly members: Property<T>[]
 }
 
 /**
@@ -98,16 +98,16 @@ export interface InterfaceType<T extends Type = Type> {
  * parameters.
  */
 export interface IntersectionType<T extends Type = Type> {
-  kind: typeof TypeKind.Intersection
-  parameters: T[]
+  readonly kind: typeof TypeKind.Intersection
+  readonly parameters: T[]
 }
 
 /**
  * An object type represents the scope of an object (e.g. its properties).
  */
 export interface ObjectType<T extends Type = Type> {
-  kind: typeof TypeKind.Object
-  properties: Property<T>[]
+  readonly kind: typeof TypeKind.Object
+  readonly properties: Property<T>[]
 }
 
 /**
@@ -115,10 +115,10 @@ export interface ObjectType<T extends Type = Type> {
  * type.
  */
 export interface ParametricType {
-  kind: typeof TypeKind.Parametric
-  name: string
-  typeArguments: Type[]
-  termArguments: SyntaxNode[]
+  readonly kind: typeof TypeKind.Parametric
+  readonly name: string
+  readonly typeArguments: Type[]
+  readonly termArguments: SyntaxNode[]
 }
 
 /**
@@ -126,9 +126,9 @@ export interface ParametricType {
  * type.
  */
 export interface RefinedType<T extends Type = Type> {
-  kind: typeof TypeKind.Refined
-  type: T
-  predicates: Predicate[]
+  readonly kind: typeof TypeKind.Refined
+  readonly type: T
+  readonly predicates: Predicate[]
 }
 
 /**
@@ -136,8 +136,8 @@ export interface RefinedType<T extends Type = Type> {
  * constrained by predicates.
  */
 export interface RefinedTerm {
-  kind: typeof TypeKind.RefinedTerm
-  name: string
+  readonly kind: typeof TypeKind.RefinedTerm
+  readonly name: string
 }
 
 /**
@@ -145,31 +145,31 @@ export interface RefinedTerm {
  * union that do not appear in the right union.
  */
 export interface SubtractionType {
-  kind: typeof TypeKind.Subtraction
-  left: Type
-  right: Type
+  readonly kind: typeof TypeKind.Subtraction
+  readonly left: Type
+  readonly right: Type
 }
 
 /**
  * A type variable that is used internally and cannot be related to other types.
  */
 export interface TemporaryTypeVariable {
-  kind: typeof TypeKind.TemporaryVariable
+  readonly kind: typeof TypeKind.TemporaryVariable
 }
 
 /**
  * A type variable represents any type.
  */
 export interface TypeVariable {
-  kind: typeof TypeKind.Variable
+  readonly kind: typeof TypeKind.Variable
 }
 
 /**
  * A union type represents the type of any of its parameters.
  */
 export interface UnionType<T extends Type = Type> {
-  kind: typeof TypeKind.Union
-  parameters: T[]
+  readonly kind: typeof TypeKind.Union
+  readonly parameters: T[]
 }
 
 // ---- Factories ----

--- a/src/util/paths.ts
+++ b/src/util/paths.ts
@@ -14,8 +14,11 @@ const IMPORT_FILE_EXTENSIONS = [
 
 const fileExists = (file: AbsolutePath) => fs.existsSync(file.path)
 
-const fileHasTonyExtension = (file: Path) =>
+export const fileHasTonyExtension = (file: Path): boolean =>
   FILE_EXTENSION_REGEX.test(file.path)
+
+export const fileHasJavaScriptExtension = (file: Path): boolean =>
+  JAVASCRIPT_FILE_EXTENSION_REGEX.test(file.path)
 
 const fileHasImportExtension = (file: Path) =>
   !!IMPORT_FILE_EXTENSIONS.find((regex) => regex.test(file.path))
@@ -51,6 +54,11 @@ export const writeFile = async (
 
 export const getOutFilename = (filename: string): string =>
   filename.replace(FILE_EXTENSION, TARGET_FILE_EXTENSION)
+
+export const getOutPath = <T extends Path>(path: T): T => ({
+  ...path,
+  path: getOutFilename(path.path),
+})
 
 export const isSamePath = (path1: AbsolutePath, path2: AbsolutePath): boolean =>
   path1.path === path2.path

--- a/src/util/scopes.ts
+++ b/src/util/scopes.ts
@@ -4,6 +4,7 @@ import {
   NestingNode,
   NestingTermNode,
   ScopeWithErrors,
+  ScopeWithNode,
   ScopeWithTerms,
   ScopeWithTypes,
   TypingEnvironment,
@@ -46,7 +47,7 @@ export const getTypeAssignments = (
 
 export const findScopeOfNode = <
   T extends NestingNode,
-  U extends FileScope<T> | NestedScope<T>
+  U extends ScopeWithNode<T>
 >(
   scopes: U[],
   node: T,

--- a/src/util/traverse.ts
+++ b/src/util/traverse.ts
@@ -1,6 +1,7 @@
+import { NamedNode, SyntaxNode } from 'tree-sitter-tony'
+import { NestingNode, isNestingNode } from '../types/analyze/scopes'
 import { AbstractState } from '../types/state'
 import { ErrorAnnotation } from '../types/errors/annotations'
-import { SyntaxNode } from 'tree-sitter-tony'
 import { addErrorToScope } from './scopes'
 
 export const addError = <T extends AbstractState>(
@@ -44,4 +45,17 @@ export const conditionalApply = <T extends AbstractState, U>(
 ) => (state: T, arg: U | undefined): T => {
   if (arg) return callback(state, arg)
   return state
+}
+
+/**
+ * If node is a nesting node enter its scope; otherwise just apply the given
+ * callback.
+ */
+export const traverseScopes = <T extends NamedNode, U>(
+  node: T,
+  callback: () => U,
+  nest: (node: NestingNode & T) => U,
+): U => {
+  if (isNestingNode(node)) return nest(node)
+  else return callback()
 }

--- a/src/util/traverse.ts
+++ b/src/util/traverse.ts
@@ -38,13 +38,23 @@ export const ensure = <T extends AbstractState, U extends SyntaxNode>(
 }
 
 /**
- * Conditionally applies argument to callback depending on whether it exists.
+ * Conditionally applies argument to state reduces depending on whether it
+ * exists.
  */
 export const conditionalApply = <T extends AbstractState, U>(
   callback: (state: T, arg: U) => T,
 ) => (state: T, arg: U | undefined): T => {
   if (arg) return callback(state, arg)
   return state
+}
+
+/**
+ * Conditionally applies argument to callback depending on whether it exists.
+ */
+export const safeApply = <T extends AbstractState, U, V>(
+  callback: (state: T, arg: U) => V,
+) => (state: T, arg: U | undefined): V | undefined => {
+  if (arg) return callback(state, arg)
 }
 
 /**

--- a/src/util/traverse.ts
+++ b/src/util/traverse.ts
@@ -1,13 +1,9 @@
+import { AbstractState } from '../types/state'
 import { ErrorAnnotation } from '../types/errors/annotations'
-import { ScopeWithErrors } from '../types/analyze/scopes'
 import { SyntaxNode } from 'tree-sitter-tony'
 import { addErrorToScope } from './scopes'
 
-type State = {
-  scopes: ScopeWithErrors[]
-}
-
-export const addError = <T extends State>(
+export const addError = <T extends AbstractState>(
   state: T,
   node: SyntaxNode,
   error: ErrorAnnotation,
@@ -20,7 +16,7 @@ export const addError = <T extends State>(
   }
 }
 
-export const addErrorUnless = <T extends State>(
+export const addErrorUnless = <T extends AbstractState>(
   predicate: boolean,
   error: ErrorAnnotation,
 ) => (state: T, node: SyntaxNode): T => {
@@ -31,7 +27,7 @@ export const addErrorUnless = <T extends State>(
 /**
  * Checks predicate. If true, returns callback. Else, adds error annotation.
  */
-export const ensure = <T extends State, U extends SyntaxNode>(
+export const ensure = <T extends AbstractState, U extends SyntaxNode>(
   predicate: (state: T, node: U) => boolean,
   callback: (state: T, node: U) => T,
   error: ErrorAnnotation,
@@ -43,7 +39,7 @@ export const ensure = <T extends State, U extends SyntaxNode>(
 /**
  * Conditionally applies argument to callback depending on whether it exists.
  */
-export const conditionalApply = <T extends State, U>(
+export const conditionalApply = <T extends AbstractState, U>(
   callback: (state: T, arg: U) => T,
 ) => (state: T, arg: U | undefined): T => {
   if (arg) return callback(state, arg)

--- a/src/util/traverse.ts
+++ b/src/util/traverse.ts
@@ -43,19 +43,7 @@ export const ensure = <T extends AbstractState, U extends SyntaxNode>(
  */
 export const conditionalApply = <T extends AbstractState, U>(
   callback: (state: T, arg: U) => T,
-) => (state: T, arg: U | undefined): T => {
-  if (arg) return callback(state, arg)
-  return state
-}
-
-/**
- * Conditionally applies argument to callback depending on whether it exists.
- */
-export const safeApply = <T extends AbstractState, U, V>(
-  callback: (state: T, arg: U) => V,
-) => (state: T, arg: U | undefined): V | undefined => {
-  if (arg) return callback(state, arg)
-}
+) => (state: T, arg: U | undefined): T => (arg && callback(state, arg)) || state
 
 /**
  * If node is a nesting node enter its scope; otherwise just apply the given


### PR DESCRIPTION
from https://github.com/tony-lang/tony/tree/0b11e76c7a7946c082b52dc65268d57d3422fb59/src/code_generation

- [x] generalize walking scope stacks
- [x] nest, enterBlock for code generation
- [x] encode absence of error nodes in types
- [x] handle all nodes that were handled previously
- [x] generate patterns
- [x] generate imports
- [x] attempt removing type hints in `handleNode` (or create follow-up ticket)